### PR TITLE
약관 생성 기본 API 구조 세팅

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -1,3 +1,24 @@
 dependencies {
     implementation project(':common') // 공통 모듈 참조
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.16.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.16.1'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'net.bytebuddy:byte-buddy-agent:1.12.20'
+
+    compileOnly 'org.projectlombok:lombok:1.18.36'
+    annotationProcessor 'org.projectlombok:lombok:1.18.36'
+    testCompileOnly 'org.projectlombok:lombok:1.18.36'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.36'
+}
+
+
+tasks.named('test') {
+    useJUnitPlatform()
+    jvmArgs += ['-Xshare:off']
+    jvmArgs += '-javaagent:' + configurations.testRuntimeClasspath.find { it.name.contains("byte-buddy-agent") }
 }

--- a/admin/src/main/java/com/reservation/admin/terms/controller/TermsController.java
+++ b/admin/src/main/java/com/reservation/admin/terms/controller/TermsController.java
@@ -1,0 +1,35 @@
+package com.reservation.admin.terms.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.reservation.admin.terms.controller.dto.AdminCreateTermsRequest;
+import com.reservation.admin.terms.service.TermsService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/terms")
+@Tag(name = "약관 API", description = "관리자용 약관 관리 API입니다.")
+@RequiredArgsConstructor
+public class TermsController {
+	private final TermsService termsService;
+
+	@Operation(summary = "약관 등록", description = "관리자가 새로운 약관을 등록합니다.")
+	@ApiResponse(responseCode = "201", description = "등록 성공", content = @Content(schema = @Schema(implementation = Long.class)))
+	@PostMapping
+	public ResponseEntity<Long> createTerms(@Valid @RequestBody AdminCreateTermsRequest request) {
+		Long termsId = termsService.createTerms(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(termsId);
+	}
+}

--- a/admin/src/main/java/com/reservation/admin/terms/controller/dto/AdminCreateClauseRequest.java
+++ b/admin/src/main/java/com/reservation/admin/terms/controller/dto/AdminCreateClauseRequest.java
@@ -1,0 +1,11 @@
+package com.reservation.admin.terms.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminCreateClauseRequest(
+	@Min(1) Integer clauseOrder,
+	@NotBlank String title,
+	@NotBlank String content
+) {
+}

--- a/admin/src/main/java/com/reservation/admin/terms/controller/dto/AdminCreateTermsRequest.java
+++ b/admin/src/main/java/com/reservation/admin/terms/controller/dto/AdminCreateTermsRequest.java
@@ -1,0 +1,23 @@
+package com.reservation.admin.terms.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminCreateTermsRequest(
+	@NotNull String code,
+	@NotBlank String title,
+	@NotNull String type,
+	@NotNull String status,
+	@NotNull LocalDateTime exposedFrom,
+	@Future LocalDateTime exposedTo,
+	@Min(1) Integer displayOrder,
+	@NotEmpty List<@Valid AdminCreateClauseRequest> clauses
+) {
+}

--- a/admin/src/main/java/com/reservation/admin/terms/service/TermsService.java
+++ b/admin/src/main/java/com/reservation/admin/terms/service/TermsService.java
@@ -1,0 +1,14 @@
+package com.reservation.admin.terms.service;
+
+import org.springframework.stereotype.Service;
+
+import com.reservation.admin.terms.controller.dto.AdminCreateTermsRequest;
+
+import jakarta.validation.Valid;
+
+@Service
+public class TermsService {
+	public Long createTerms(@Valid AdminCreateTermsRequest request) {
+		return 1L;
+	}
+}

--- a/admin/src/test/java/com/reservation/admin/terms/service/TermsServiceTest.java
+++ b/admin/src/test/java/com/reservation/admin/terms/service/TermsServiceTest.java
@@ -1,0 +1,42 @@
+package com.reservation.admin.terms.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.reservation.admin.terms.controller.dto.AdminCreateClauseRequest;
+import com.reservation.admin.terms.controller.dto.AdminCreateTermsRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class TermsServiceTest {
+	@InjectMocks
+	private TermsService termsService;
+
+	@Test
+	void 약관저장_성공ID반환() {
+		// given
+		AdminCreateTermsRequest request = new AdminCreateTermsRequest(
+			"TERMS_USE",
+			"서비스 이용약관",
+			"REQUIRED",
+			"ACTIVE",
+			LocalDateTime.of(2025, 3, 25, 0, 0),
+			LocalDateTime.of(2026, 3, 25, 0, 0),
+			1,
+			List.of(
+				new AdminCreateClauseRequest(1, "제1조 (목적)", "이 약관은..."),
+				new AdminCreateClauseRequest(2, "제2조 (정의)", "여기서 사용하는 용어는...")
+			)
+		);
+
+		Long id = termsService.createTerms(request);
+
+		assertThat(id).isEqualTo(1L);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #3 
- #4 
- #5 
- #6 

## 📝작업 내용
- 약관 생성 기본 API Spec 설계
- admin 모듈 spring swagger 세팅
- 약관 생성 API 기본 구조 세팅 (Controller, Service) 

### 스크린샷 (선택)
<img width="424" alt="image" src="https://github.com/user-attachments/assets/57f8b6a3-7197-4886-8c54-92d17fc967de" />


## 💬리뷰 요구사항(선택)
- 요구 사항 분석을 통해, 약관 생성에 대한 API Spec 설계가 해당 PR의 주된 목적입니다