### PR TITLE
성공 응답 래핑 구조 도입

### DIFF
--- a/admin/src/main/java/com/reservation/admin/terms/controller/TermsController.java
+++ b/admin/src/main/java/com/reservation/admin/terms/controller/TermsController.java
@@ -1,8 +1,8 @@
 package com.reservation.admin.terms.controller;
 
-import org.springframework.http.HttpStatus;
+import static com.reservation.common.support.response.ApiResponses.*;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.reservation.admin.terms.controller.dto.AdminCreateTermsRequest;
 import com.reservation.admin.terms.service.TermsService;
+import com.reservation.common.response.ApiSuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,10 +28,10 @@ public class TermsController {
 	private final TermsService termsService;
 
 	@Operation(summary = "약관 등록", description = "관리자가 새로운 약관을 등록합니다.")
-	@ApiResponse(responseCode = "201", description = "등록 성공", content = @Content(schema = @Schema(implementation = Long.class)))
+	@ApiResponse(responseCode = "201", description = "등록 성공", content = @Content(schema = @Schema(implementation = ApiSuccessResponse.class)))
 	@PostMapping
-	public ResponseEntity<Long> createTerms(@Valid @RequestBody AdminCreateTermsRequest request) {
+	public ResponseEntity<ApiSuccessResponse<Long>> createTerms(@Valid @RequestBody AdminCreateTermsRequest request) {
 		Long termsId = termsService.createTerms(request);
-		return ResponseEntity.status(HttpStatus.CREATED).body(termsId);
+		return created(termsId);
 	}
 }

--- a/admin/src/main/java/com/reservation/admin/terms/service/TermsService.java
+++ b/admin/src/main/java/com/reservation/admin/terms/service/TermsService.java
@@ -12,8 +12,6 @@ import com.reservation.commonapi.terms.repository.dto.AdminTermsDto;
 import com.reservation.commonmodel.terms.TermsCode;
 import com.reservation.commonmodel.terms.TermsStatus;
 
-import ch.qos.logback.core.spi.ErrorCodes;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 

--- a/admin/src/test/java/com/reservation/admin/terms/service/TermsServiceTest.java
+++ b/admin/src/test/java/com/reservation/admin/terms/service/TermsServiceTest.java
@@ -2,8 +2,7 @@ package com.reservation.admin.terms.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;

--- a/common/src/main/java/com/reservation/common/response/ApiSuccessResponse.java
+++ b/common/src/main/java/com/reservation/common/response/ApiSuccessResponse.java
@@ -1,0 +1,11 @@
+package com.reservation.common.response;
+
+public record ApiSuccessResponse<T>(
+	boolean success,
+	T data
+) {
+	public static <T> ApiSuccessResponse<T> of(T data) {
+		return new ApiSuccessResponse<>(true, data);
+	}
+}
+

--- a/common/src/main/java/com/reservation/common/support/response/ApiResponses.java
+++ b/common/src/main/java/com/reservation/common/support/response/ApiResponses.java
@@ -1,0 +1,20 @@
+package com.reservation.common.support.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.reservation.common.response.ApiSuccessResponse;
+
+public class ApiResponses {
+	public static <T> ResponseEntity<ApiSuccessResponse<T>> ok(T data) {
+		return ResponseEntity.ok(new ApiSuccessResponse<>(true, data));
+	}
+
+	public static <T> ResponseEntity<ApiSuccessResponse<T>> created(T data) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(new ApiSuccessResponse<>(true, data));
+	}
+
+	public static ResponseEntity<Void> noContent() {
+		return ResponseEntity.noContent().build();
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #14 

## 📝작업 내용

1. ApiResponses 및 ApiSuccessResponse 설계
2. Contoller return 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- #13 예외 처리 공통 구조를 도입하면서, 응답 구조도 일관성있게 맞추는 작업을 먼저 처리하였습니다