### PR TITLE
요청/응답 로깅 기능 도입

### DIFF
--- a/common/src/main/java/com/reservation/common/logging/RequestLoggingFilter.java
+++ b/common/src/main/java/com/reservation/common/logging/RequestLoggingFilter.java
@@ -1,0 +1,76 @@
+package com.reservation.common.logging;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(RequestLoggingFilter.class);
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+		throws ServletException, IOException {
+
+		// 1. Trace ID 생성
+		String traceId = UUID.randomUUID().toString().substring(0, 8);
+		MDC.put("traceId", traceId); // 로그에 traceId 자동 삽입
+		long startTime = System.currentTimeMillis();
+
+		ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+		ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+
+		try {
+			// 2. 요청 정보 로그
+			log.info("➡️ [{}] {} {}", getClientIp(request), request.getMethod(), request.getRequestURI());
+
+			chain.doFilter(wrappedRequest, wrappedResponse);
+
+		} finally {
+			long duration = System.currentTimeMillis() - startTime;
+
+			// 3. 요청 바디 로그
+			String requestBody = new String(wrappedRequest.getContentAsByteArray(), StandardCharsets.UTF_8);
+
+			// 4. 응답 바디 로그
+			String responseBody = new String(wrappedResponse.getContentAsByteArray(), StandardCharsets.UTF_8);
+			wrappedResponse.copyBodyToResponse(); // body 재전송!
+
+			log.info("⬅️ [{}] {} {} ({}ms)\n📝 요청 바디: {}\n📦 응답 바디: {}",
+				getClientIp(request),
+				request.getMethod(),
+				request.getRequestURI(),
+				duration,
+				requestBody,
+				responseBody
+			);
+
+			MDC.clear();
+		}
+	}
+
+	private String getClientIp(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+		if (ip == null || ip.isBlank()) {
+			ip = request.getRemoteAddr();
+		}
+		return ip;
+	}
+}

--- a/common/src/main/resources/logback-spring.xml
+++ b/common/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #16 

## 📝작업 내용

1. 요청, 응답 모두 로그를 남기기 위해 LoggingFilter 구현


### 스크린샷 (선택)

<img width="750" alt="image" src="https://github.com/user-attachments/assets/4ebecc05-5ab2-4dfb-b6c7-c99a0fb459b4" />


## 💬리뷰 요구사항(선택)

- 현재로선 필수 로그 정보인 요청과 응답 Body, Request IP, 엔드포인트 정도만 처리해두었습니다 
- 추가로 로그 기록을 추적하기 위한 trace id를 적용해두었습니다