### PR TITLE
Request DTO 바인딩 예외 핸들링 추가

### DIFF
--- a/common/src/main/java/com/reservation/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/reservation/common/exception/GlobalExceptionHandler.java
@@ -60,9 +60,7 @@ public class GlobalExceptionHandler {
 		String param = methodArgumentTypeMismatchException.getName();
 		Object value = methodArgumentTypeMismatchException.getValue();
 		String invalidValue = value != null ? value.toString() : "null";
-
-		System.out.println(methodArgumentTypeMismatchException.getMessage());
-
+		
 		String responseCode = ErrorCode.VALIDATION_ERROR.name();
 		String message = String.format("'%s' 파라미터에 잘못된 값 '%s'이(가) 전달되었습니다.", param, invalidValue);
 		ApiErrorResponse response = of(responseCode, message);
@@ -73,8 +71,6 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ApiErrorResponse> handleValidationException(
 		MethodArgumentNotValidException methodArgumentNotValidException) {
-
-		System.out.println(methodArgumentNotValidException.getMessage());
 
 		List<FieldError> fieldErrors = methodArgumentNotValidException.getBindingResult().getFieldErrors();
 		String message = fieldErrors.stream()

--- a/common/src/main/java/com/reservation/common/support/validation/ModelAttributeValidator.java
+++ b/common/src/main/java/com/reservation/common/support/validation/ModelAttributeValidator.java
@@ -10,7 +10,14 @@ public class ModelAttributeValidator {
 	public static void validate(BindingResult bindingResult) {
 		if (bindingResult.hasErrors()) {
 			String errorMessage = bindingResult.getFieldErrors().stream()
-				.map(error -> String.format("[%s] %s", error.getField(), error.getDefaultMessage()))
+				.map(error -> {
+					String fieldName = error.getField();
+					String message = error.getDefaultMessage();
+					if (message != null && message.contains("Failed to convert")) {
+						message = "잘못된 enum 값입니다.";
+					}
+					return String.format("[%s] %s", fieldName, message);
+				})
 				.collect(Collectors.joining(" | "));
 
 			throw ErrorCode.VALIDATION_ERROR.exception(errorMessage);


### PR DESCRIPTION
## #️⃣연관된 이슈

- 없음

## 📝작업 내용

1. `@ModelAttribute` 사용시 DTO 바인딩 validate 메서드에 enum 타입 예외 메시지 추가
2. GlobalExceptionHandler DTO 바인딩 예외 메서드 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- Request DTO에서 enum 타입에 대한 예외 핸들링을 위한 작업입니다
- `@ModelAttribute` 사용 시, 스프링이 내부적으로 바인딩 예외를 swallow 해버리는 점을 알게됩니다
- `@ModelAttribute` 내부적으로 예외를 swallow 해버리는 지점을 수정하여 커스텀한 `@SageModelAttribute` 어노테이션을 구축하려 했으나, 제 생각보다 더 깊이있는 내용을 다뤄야할 것 같아 좀 더 파악후 적용하려 합니다