### PR TITLE
약관 상세 조회 API 개발

### DIFF
--- a/admin/src/main/java/com/reservation/admin/terms/controller/TermsController.java
+++ b/admin/src/main/java/com/reservation/admin/terms/controller/TermsController.java
@@ -4,6 +4,8 @@ import static com.reservation.common.response.ApiResponse.*;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,9 +22,11 @@ import com.reservation.common.response.ApiResponse;
 import com.reservation.commonapi.admin.query.sort.AdminTermsSortCursor;
 import com.reservation.commonapi.admin.repository.dto.AdminTermsDto;
 import com.reservation.commonmodel.keyset.KeysetPage;
+import com.reservation.commonmodel.terms.TermsDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -57,8 +61,17 @@ public class TermsController {
 
 	@PostMapping("/search-keyset")
 	@Operation(summary = "약관 리스트 조회 [커서 방식]", description = "관리자가 약관 리스트를 조회합니다.")
-	public ApiResponse<KeysetPage> findTermsByKeyset(@Valid @RequestBody TermsKeysetSearchCondition condition) {
+	public ApiResponse<KeysetPage<AdminTermsDto, AdminTermsSortCursor>> findTermsByKeyset(
+		@Valid @RequestBody TermsKeysetSearchCondition condition) {
 		KeysetPage<AdminTermsDto, AdminTermsSortCursor> terms = termsService.findTermsByKeyset(condition);
 		return ok(terms);
+	}
+
+	@GetMapping("/{id}")
+	@Operation(summary = "약관 상세 조회", description = "약관 상세 조회합니다.")
+	public ApiResponse<TermsDto> findById(
+		@Nonnull @PathVariable Long id) {
+		TermsDto findTerms = termsService.findById(id);
+		return ok(findTerms);
 	}
 }

--- a/admin/src/main/java/com/reservation/admin/terms/controller/dto/response/TermsDetailResponse.java
+++ b/admin/src/main/java/com/reservation/admin/terms/controller/dto/response/TermsDetailResponse.java
@@ -1,0 +1,22 @@
+package com.reservation.admin.terms.controller.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.reservation.commonmodel.terms.TermsCode;
+import com.reservation.commonmodel.terms.TermsStatus;
+import com.reservation.commonmodel.terms.TermsType;
+
+public record TermsDetailResponse(
+	Long id,
+	TermsCode code,
+	String title,
+	TermsType type,
+	TermsStatus status,
+	Integer version,
+	Boolean isLatest,
+	LocalDateTime exposedFrom,
+	LocalDateTime exposedToOrNull,
+	Integer displayOrder,
+	LocalDateTime createdAt
+) {
+}

--- a/admin/src/main/java/com/reservation/admin/terms/service/TermsService.java
+++ b/admin/src/main/java/com/reservation/admin/terms/service/TermsService.java
@@ -99,7 +99,12 @@ public class TermsService {
 
 	public KeysetPage<AdminTermsDto, AdminTermsSortCursor> findTermsByKeyset(TermsKeysetSearchCondition condition) {
 		AdminTermsKeysetQueryCondition queryCondition = fromSearchConditionToQueryKeysetCondition(condition);
-		
+
 		return this.adminTermsRepository.findTermsByKeysetCondition(queryCondition);
+	}
+
+	public TermsDto findById(Long id) {
+		return this.adminTermsRepository.findWithClausesById(id)
+			.orElseThrow(() -> ErrorCode.NOT_FOUND.exception("존재하지 않는 약관입니다."));
 	}
 }

--- a/common-api/src/main/java/com/reservation/commonapi/admin/repository/AdminTermsRepository.java
+++ b/common-api/src/main/java/com/reservation/commonapi/admin/repository/AdminTermsRepository.java
@@ -26,4 +26,6 @@ public interface AdminTermsRepository {
 
 	KeysetPage<AdminTermsDto, AdminTermsSortCursor> findTermsByKeysetCondition(
 		AdminTermsKeysetQueryCondition condition); // Query keyset Condition 조회
+
+	Optional<TermsDto> findWithClausesById(Long id);
 }

--- a/common/src/main/java/com/reservation/common/terms/repository/TermsRepository.java
+++ b/common/src/main/java/com/reservation/common/terms/repository/TermsRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.reservation.common.clause.domain.QClause;
 import com.reservation.common.terms.domain.QTerms;
 import com.reservation.common.terms.domain.Terms;
 import com.reservation.common.terms.repository.cursorutil.AdminTermsCursorUtils;
@@ -34,6 +35,7 @@ public class TermsRepository implements AdminTermsRepository {
 	private final JPAQueryFactory queryFactory;
 	private final JpaTermsRepository jpaTermsRepository;
 	private final QTerms terms = QTerms.terms;
+	private final QClause clause = QClause.clause;
 
 	public TermsRepository(JPAQueryFactory queryFactory, JpaTermsRepository jpaTermsRepository) {
 		this.queryFactory = queryFactory;
@@ -167,5 +169,16 @@ public class TermsRepository implements AdminTermsRepository {
 			hasNext,
 			hasNext ? nextCursors : null
 		);
+	}
+
+	@Override
+	public Optional<TermsDto> findWithClausesById(Long id) {
+		Terms result = queryFactory
+			.selectFrom(terms)
+			.leftJoin(terms.clauseList, clause).fetchJoin() // fetch join으로 N+1 방지
+			.where(terms.id.eq(id))
+			.fetchOne();
+		Optional<Terms> optionalResult = Optional.ofNullable(result);
+		return optionalResult.map(TermsDtoMapper::fromTerms);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #27 

## 📝작업 내용

1. 약관 상세 조회 API 스펙 설계
2. 약관 상세 조회 로직 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- N+1 문제 파악 후 해결하기 위한 방안으로 `@Query` 어노테이션을 활용한 fetch join 혹은 Query DSL 활용이 있었습니다.
- 현 API 구조상 `@Query` 어노테이션 활용이 더 간단하나,
- Query DSL 활용 연습을 많이 해야할 것 같아 Query DSL을 활용한 fetch join으로 구현했습니다.