### PR TITLE
customer 모듈 약관 조회 API 개발

### DIFF
--- a/common-api/src/main/java/com/reservation/commonapi/customer/query/CustomerTermsQueryCondition.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/query/CustomerTermsQueryCondition.java
@@ -1,0 +1,8 @@
+package com.reservation.commonapi.customer.query;
+
+import org.springframework.data.domain.PageRequest;
+
+public record CustomerTermsQueryCondition(
+	PageRequest pageRequest
+) {
+}

--- a/common-api/src/main/java/com/reservation/commonapi/customer/query/sort/CustomerTermsSortCondition.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/query/sort/CustomerTermsSortCondition.java
@@ -1,0 +1,14 @@
+package com.reservation.commonapi.customer.query.sort;
+
+import org.springframework.data.domain.Sort;
+
+import com.reservation.commonmodel.sort.SortCondition;
+
+import jakarta.annotation.Nonnull;
+
+public record CustomerTermsSortCondition(
+	@Nonnull CustomerTermsSortField field,
+	@Nonnull Sort.Direction direction
+) implements SortCondition<CustomerTermsSortField> {
+}
+

--- a/common-api/src/main/java/com/reservation/commonapi/customer/query/sort/CustomerTermsSortField.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/query/sort/CustomerTermsSortField.java
@@ -1,0 +1,17 @@
+package com.reservation.commonapi.customer.query.sort;
+
+import com.reservation.commonmodel.sort.SortField;
+
+import lombok.Getter;
+
+@Getter
+public enum CustomerTermsSortField implements SortField {
+	CREATED_AT("createdAt"),// 생성일
+	DISPLAY_ORDER("displayOrder"); // 노출순서
+
+	private final String fieldName;
+
+	CustomerTermsSortField(String fieldName) {
+		this.fieldName = fieldName;
+	}
+}

--- a/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerTermsRepository.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerTermsRepository.java
@@ -1,0 +1,11 @@
+package com.reservation.commonapi.customer.repository;
+
+import org.springframework.data.domain.Page;
+
+import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
+import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+
+public interface CustomerTermsRepository {
+	Page<CustomerTermsDto> findTermsByCondition(CustomerTermsQueryCondition condition); // Query Condition 조회
+
+}

--- a/common-api/src/main/java/com/reservation/commonapi/customer/repository/dto/CustomerTermsDto.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/repository/dto/CustomerTermsDto.java
@@ -1,0 +1,44 @@
+package com.reservation.commonapi.customer.repository.dto;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.reservation.commonmodel.terms.TermsCode;
+import com.reservation.commonmodel.terms.TermsStatus;
+import com.reservation.commonmodel.terms.TermsType;
+
+import lombok.Getter;
+
+@Getter
+public class CustomerTermsDto {
+	Long id;
+	TermsCode code;
+	String title;
+	TermsType type;
+	TermsStatus status;
+	Integer version;
+	LocalDateTime exposedFrom;
+	Integer displayOrder;
+
+	@QueryProjection
+	public CustomerTermsDto(
+		Long id,
+		TermsCode code,
+		String title,
+		TermsType type,
+		TermsStatus status,
+		Integer version,
+		LocalDateTime exposedFrom,
+		Integer displayOrder
+	) {
+		this.id = id;
+		this.code = code;
+		this.title = title;
+		this.type = type;
+		this.status = status;
+		this.version = version;
+		this.exposedFrom = exposedFrom;
+		this.displayOrder = displayOrder;
+	}
+}
+

--- a/customer/build.gradle
+++ b/customer/build.gradle
@@ -1,3 +1,27 @@
 dependencies {
-    implementation project (':common') // 공통 모듈 참조
+    implementation project(':common') // 공통 모듈 참조
+    implementation project(':common-model') // 공통 model 모듈 참조
+    implementation project(':common-api') // 공통 model 모듈 참조
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.16.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.16.1'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'net.bytebuddy:byte-buddy-agent:1.12.20'
+
+    compileOnly 'org.projectlombok:lombok:1.18.36'
+    annotationProcessor 'org.projectlombok:lombok:1.18.36'
+    testCompileOnly 'org.projectlombok:lombok:1.18.36'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.36'
+}
+
+
+tasks.named('test') {
+    useJUnitPlatform()
+    jvmArgs += ['-Xshare:off']
+    jvmArgs += '-javaagent:' + configurations.testRuntimeClasspath.find { it.name.contains("byte-buddy-agent") }
 }

--- a/customer/src/main/java/com/reservation/customer/CustomerApplication.java
+++ b/customer/src/main/java/com/reservation/customer/CustomerApplication.java
@@ -3,7 +3,10 @@ package com.reservation.customer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {
+	"com.reservation.customer",
+	"com.reservation.common"
+})
 public class CustomerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(CustomerApplication.class, args);

--- a/customer/src/main/java/com/reservation/customer/terms/controller/TermsController.java
+++ b/customer/src/main/java/com/reservation/customer/terms/controller/TermsController.java
@@ -1,0 +1,35 @@
+package com.reservation.customer.terms.controller;
+
+import static com.reservation.common.response.ApiResponse.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reservation.common.response.ApiResponse;
+import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+import com.reservation.customer.terms.service.TermsService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/terms")
+@Tag(name = "약관 API", description = "고객용 약관 관리 API입니다.")
+@RequiredArgsConstructor
+public class TermsController {
+	private final TermsService termsService;
+
+	@PostMapping("/search")
+	@Operation(summary = "약관 리스트 조회", description = "최신 버전 & 현재 사용 중인 약관 리스트를 조회합니다.")
+	public ApiResponse<Page<CustomerTermsDto>> findTerms(@Valid @RequestBody TermsSearchCondition condition) {
+		Page<CustomerTermsDto> terms = termsService.findTerms(condition);
+		return ok(terms);
+	}
+
+}

--- a/customer/src/main/java/com/reservation/customer/terms/controller/dto/request/TermsSearchCondition.java
+++ b/customer/src/main/java/com/reservation/customer/terms/controller/dto/request/TermsSearchCondition.java
@@ -1,0 +1,41 @@
+package com.reservation.customer.terms.controller.dto.request;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+
+import com.reservation.common.request.PageableRequest;
+import com.reservation.commonapi.customer.query.sort.CustomerTermsSortCondition;
+import com.reservation.commonapi.customer.query.sort.CustomerTermsSortField;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record TermsSearchCondition(
+	@Min(0)
+	@Nullable
+	Integer page,
+
+	@Min(10) @Max(100)
+	@Nullable
+	Integer size,
+
+	@Nullable
+	List<CustomerTermsSortCondition> sorts
+) implements PageableRequest<CustomerTermsSortCondition> {
+	private static final int DEFAULT_PAGE_SIZE = 10;
+
+	@Schema(hidden = true)
+	@Override
+	public Sort.Order getDefaultSortOrder() {
+		return new Sort.Order(Sort.Direction.DESC, CustomerTermsSortField.DISPLAY_ORDER.getFieldName());
+	}
+
+	@Schema(hidden = true)
+	@Override
+	public int defaultPageSize() {
+		return DEFAULT_PAGE_SIZE;
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/terms/service/TermsService.java
+++ b/customer/src/main/java/com/reservation/customer/terms/service/TermsService.java
@@ -1,0 +1,27 @@
+package com.reservation.customer.terms.service;
+
+import static com.reservation.customer.terms.service.mapper.CustomerTermsQueryConditionMapper.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
+import com.reservation.commonapi.customer.repository.CustomerTermsRepository;
+import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class TermsService {
+	private final CustomerTermsRepository termsRepository;
+
+	public Page<CustomerTermsDto> findTerms(TermsSearchCondition condition) {
+		CustomerTermsQueryCondition queryCondition = fromSearchConditionToQueryCondition(condition);
+
+		return this.termsRepository.findTermsByCondition(queryCondition);
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/terms/service/mapper/CustomerTermsQueryConditionMapper.java
+++ b/customer/src/main/java/com/reservation/customer/terms/service/mapper/CustomerTermsQueryConditionMapper.java
@@ -1,0 +1,12 @@
+package com.reservation.customer.terms.service.mapper;
+
+import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
+import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+
+public class CustomerTermsQueryConditionMapper {
+	public static CustomerTermsQueryCondition fromSearchConditionToQueryCondition(TermsSearchCondition condition) {
+		return new CustomerTermsQueryCondition(
+			condition.toPageRequest()
+		);
+	}
+}

--- a/customer/src/test/java/com/reservation/customer/terms/service/TermsServiceTest.java
+++ b/customer/src/test/java/com/reservation/customer/terms/service/TermsServiceTest.java
@@ -1,0 +1,59 @@
+package com.reservation.customer.terms.service;
+
+import static com.reservation.customer.terms.service.mapper.CustomerTermsQueryConditionMapper.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+
+import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
+import com.reservation.commonapi.customer.query.sort.CustomerTermsSortCondition;
+import com.reservation.commonapi.customer.query.sort.CustomerTermsSortField;
+import com.reservation.commonapi.customer.repository.CustomerTermsRepository;
+import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+
+@ExtendWith(MockitoExtension.class)
+public class TermsServiceTest {
+
+	@Mock
+	private CustomerTermsRepository termsRepository;
+
+	@InjectMocks
+	private TermsService termsService;
+
+	private TermsSearchCondition searchCondition;
+
+	@BeforeEach
+	void setUp() {
+		searchCondition = new TermsSearchCondition(
+			0,
+			10,
+			List.of(new CustomerTermsSortCondition(CustomerTermsSortField.DISPLAY_ORDER, Sort.Direction.DESC))
+		);
+	}
+
+	@Test
+	@DisplayName("약관 리스트 조회 성공")
+	void findTerms_ReturnsTermsList() {
+		CustomerTermsQueryCondition queryCondition = fromSearchConditionToQueryCondition(searchCondition);
+		Page<CustomerTermsDto> expectedPage = mock(Page.class);
+
+		when(termsRepository.findTermsByCondition(queryCondition)).thenReturn(expectedPage);
+
+		Page<CustomerTermsDto> result = termsService.findTerms(searchCondition);
+
+		assertThat(result).isEqualTo(expectedPage);
+		verify(termsRepository).findTermsByCondition(queryCondition);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #29 

## 📝작업 내용

1. customer 모듈 전용 약관 조회 API 스펙 설계
2. customer 모듈 전용 기능 분리
3. 약관 조회 API 기능 구현 및 테스트 작성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- admin 모듈의 약관 조회 API와 다른 필터 조건을 가지며, 기본적으로 관리자가 설정한 `DISPLAY_ORDER` 값을 기준으로 정렬됩니다
