### PR TITLE
customer 모듈 약관 상세 조회 API 개발

### DIFF
--- a/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerTermsRepository.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerTermsRepository.java
@@ -1,11 +1,15 @@
 package com.reservation.commonapi.customer.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 
 import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
 import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+import com.reservation.commonmodel.terms.TermsDto;
 
 public interface CustomerTermsRepository {
 	Page<CustomerTermsDto> findTermsByCondition(CustomerTermsQueryCondition condition); // Query Condition 조회
 
+	Optional<TermsDto> findById(Long id); // 약관 ID로 단일 조회
 }

--- a/customer/src/main/java/com/reservation/customer/terms/controller/TermsController.java
+++ b/customer/src/main/java/com/reservation/customer/terms/controller/TermsController.java
@@ -3,6 +3,8 @@ package com.reservation.customer.terms.controller;
 import static com.reservation.common.response.ApiResponse.*;
 
 import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.reservation.common.response.ApiResponse;
 import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
 import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+import com.reservation.customer.terms.controller.dto.response.TermsDetailResponse;
 import com.reservation.customer.terms.service.TermsService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,8 +31,14 @@ public class TermsController {
 	@PostMapping("/search")
 	@Operation(summary = "약관 리스트 조회", description = "최신 버전 & 현재 사용 중인 약관 리스트를 조회합니다.")
 	public ApiResponse<Page<CustomerTermsDto>> findTerms(@Valid @RequestBody TermsSearchCondition condition) {
-		Page<CustomerTermsDto> terms = termsService.findTerms(condition);
-		return ok(terms);
+		Page<CustomerTermsDto> termsPage = termsService.findTerms(condition);
+		return ok(termsPage);
 	}
 
+	@GetMapping("/{id}")
+	@Operation(summary = "약관 상세 조회")
+	public ApiResponse<TermsDetailResponse> findTermsById(@PathVariable Long id) {
+		TermsDetailResponse termsDetail = termsService.findById(id);
+		return ok(termsDetail);
+	}
 }

--- a/customer/src/main/java/com/reservation/customer/terms/controller/dto/response/TermsDetailResponse.java
+++ b/customer/src/main/java/com/reservation/customer/terms/controller/dto/response/TermsDetailResponse.java
@@ -1,0 +1,22 @@
+package com.reservation.customer.terms.controller.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.reservation.commonmodel.terms.ClauseDto;
+import com.reservation.commonmodel.terms.TermsCode;
+import com.reservation.commonmodel.terms.TermsStatus;
+import com.reservation.commonmodel.terms.TermsType;
+
+public record TermsDetailResponse(
+	Long id,
+	TermsCode code,
+	String title,
+	TermsType type,
+	TermsStatus status,
+	Integer version,
+	LocalDateTime exposedFrom,
+	Integer displayOrder,
+	List<ClauseDto> clauses
+) {
+}

--- a/customer/src/main/java/com/reservation/customer/terms/service/TermsService.java
+++ b/customer/src/main/java/com/reservation/customer/terms/service/TermsService.java
@@ -1,6 +1,7 @@
 package com.reservation.customer.terms.service;
 
-import static com.reservation.customer.terms.service.mapper.CustomerTermsQueryConditionMapper.*;
+import static com.reservation.customer.terms.service.mapper.TermsDetailResponseMapper.*;
+import static com.reservation.customer.terms.service.mapper.TermsQueryConditionMapper.*;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -8,7 +9,11 @@ import org.springframework.stereotype.Service;
 import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
 import com.reservation.commonapi.customer.repository.CustomerTermsRepository;
 import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+import com.reservation.commonmodel.exception.ErrorCode;
+import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.commonmodel.terms.TermsStatus;
 import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+import com.reservation.customer.terms.controller.dto.response.TermsDetailResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -23,5 +28,19 @@ public class TermsService {
 		CustomerTermsQueryCondition queryCondition = fromSearchConditionToQueryCondition(condition);
 
 		return this.termsRepository.findTermsByCondition(queryCondition);
+	}
+
+	public TermsDetailResponse findById(Long id) {
+		TermsDto termsDto = this.termsRepository.findById(id)
+			.orElseThrow(() -> ErrorCode.NOT_FOUND.exception("존재하지 않는 약관입니다."));
+
+		if (!termsDto.isLatest()) {
+			throw ErrorCode.BAD_REQUEST.exception("공개된 약관이 아닙니다.");
+		}
+		if (termsDto.status() != TermsStatus.ACTIVE) {
+			throw ErrorCode.BAD_REQUEST.exception("현재 사용 중인 약관이 아닙니다.");
+		}
+
+		return fromTermsDtoToResponse(termsDto);
 	}
 }

--- a/customer/src/main/java/com/reservation/customer/terms/service/mapper/TermsDetailResponseMapper.java
+++ b/customer/src/main/java/com/reservation/customer/terms/service/mapper/TermsDetailResponseMapper.java
@@ -1,0 +1,20 @@
+package com.reservation.customer.terms.service.mapper;
+
+import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.customer.terms.controller.dto.response.TermsDetailResponse;
+
+public class TermsDetailResponseMapper {
+	public static TermsDetailResponse fromTermsDtoToResponse(TermsDto terms) {
+		return new TermsDetailResponse(
+			terms.id(),
+			terms.code(),
+			terms.title(),
+			terms.type(),
+			terms.status(),
+			terms.version(),
+			terms.exposedFrom(),
+			terms.displayOrder(),
+			terms.clauses()
+		);
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/terms/service/mapper/TermsQueryConditionMapper.java
+++ b/customer/src/main/java/com/reservation/customer/terms/service/mapper/TermsQueryConditionMapper.java
@@ -3,7 +3,7 @@ package com.reservation.customer.terms.service.mapper;
 import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
 import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
 
-public class CustomerTermsQueryConditionMapper {
+public class TermsQueryConditionMapper {
 	public static CustomerTermsQueryCondition fromSearchConditionToQueryCondition(TermsSearchCondition condition) {
 		return new CustomerTermsQueryCondition(
 			condition.toPageRequest()

--- a/customer/src/test/java/com/reservation/customer/terms/service/TermsServiceTest.java
+++ b/customer/src/test/java/com/reservation/customer/terms/service/TermsServiceTest.java
@@ -1,10 +1,13 @@
 package com.reservation.customer.terms.service;
 
-import static com.reservation.customer.terms.service.mapper.CustomerTermsQueryConditionMapper.*;
+import static com.reservation.customer.terms.service.mapper.TermsQueryConditionMapper.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +24,14 @@ import com.reservation.commonapi.customer.query.sort.CustomerTermsSortCondition;
 import com.reservation.commonapi.customer.query.sort.CustomerTermsSortField;
 import com.reservation.commonapi.customer.repository.CustomerTermsRepository;
 import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
+import com.reservation.commonmodel.exception.BusinessException;
+import com.reservation.commonmodel.terms.ClauseDto;
+import com.reservation.commonmodel.terms.TermsCode;
+import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.commonmodel.terms.TermsStatus;
+import com.reservation.commonmodel.terms.TermsType;
 import com.reservation.customer.terms.controller.dto.request.TermsSearchCondition;
+import com.reservation.customer.terms.controller.dto.response.TermsDetailResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class TermsServiceTest {
@@ -55,5 +65,117 @@ public class TermsServiceTest {
 
 		assertThat(result).isEqualTo(expectedPage);
 		verify(termsRepository).findTermsByCondition(queryCondition);
+	}
+
+	@Test
+	@DisplayName("약관 ID로 조회 성공")
+	void findById_ReturnsTermsDetailResponse() {
+		Long id = 1L;
+		TermsDto termsDto = new TermsDto(
+			id,
+			TermsCode.TERMS_USE,
+			"서비스 이용약관",
+			TermsType.REQUIRED,
+			TermsStatus.ACTIVE,
+			1,
+			true,
+			LocalDateTime.of(2025, 3, 25, 0, 0),
+			LocalDateTime.of(2026, 3, 25, 0, 0),
+			1,
+			null,
+			null,
+			List.of(
+				new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+				new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+			)
+		);
+
+		when(termsRepository.findById(id)).thenReturn(Optional.of(termsDto));
+
+		TermsDetailResponse response = termsService.findById(id);
+
+		assertThat(response).isNotNull();
+		verify(termsRepository).findById(id);
+	}
+
+	@Test
+	@DisplayName("약관 ID로 조회 실패 - 약관이 존재하지 않음")
+	void findById_ThrowsExceptionWhenTermsNotFound() {
+		Long id = 1L;
+
+		when(termsRepository.findById(id)).thenReturn(Optional.empty());
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			termsService.findById(id);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("존재하지 않는 약관입니다.");
+		verify(termsRepository).findById(id);
+	}
+
+	@Test
+	@DisplayName("약관 ID로 조회 실패 - 공개된 약관이 아님")
+	void findById_ThrowsExceptionWhenTermsNotLatest() {
+		Long id = 1L;
+		TermsDto termsDto = new TermsDto(
+			id,
+			TermsCode.TERMS_USE,
+			"서비스 이용약관",
+			TermsType.REQUIRED,
+			TermsStatus.ACTIVE,
+			1,
+			false, // isLatest가 false
+			LocalDateTime.of(2025, 3, 25, 0, 0),
+			LocalDateTime.of(2026, 3, 25, 0, 0),
+			1,
+			null,
+			null,
+			List.of(
+				new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+				new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+			)
+		);
+
+		when(termsRepository.findById(id)).thenReturn(Optional.of(termsDto));
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			termsService.findById(id);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("공개된 약관이 아닙니다.");
+		verify(termsRepository).findById(id);
+	}
+
+	@Test
+	@DisplayName("약관 ID로 조회 실패 - 현재 사용 중인 약관이 아님")
+	void findById_ThrowsExceptionWhenTermsNotActive() {
+		Long id = 1L;
+		TermsDto termsDto = new TermsDto(
+			id,
+			TermsCode.TERMS_USE,
+			"서비스 이용약관",
+			TermsType.REQUIRED,
+			TermsStatus.INACTIVE, // TermsStatus가 ACTIVE가 아님
+			1,
+			true,
+			LocalDateTime.of(2025, 3, 25, 0, 0),
+			LocalDateTime.of(2026, 3, 25, 0, 0),
+			1,
+			null,
+			null,
+			List.of(
+				new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+				new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+			)
+		);
+
+		when(termsRepository.findById(id)).thenReturn(Optional.of(termsDto));
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			termsService.findById(id);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("현재 사용 중인 약관이 아닙니다.");
+		verify(termsRepository).findById(id);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #31 

## 📝작업 내용

1. customer 전용 약관 상세조회 API 스펙 설계
2. customer 전용 약관 상세조회 API 기능 구현 및 테스트 작성


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 고객 전용 API로, 현재 사용 중인 최신 약관만 조회 가능하도록 설계했습니다