### PR TITLE
회원 가입 API 개발

### DIFF
--- a/admin/src/main/java/com/reservation/admin/terms/service/mapper/TermsDtoMapper.java
+++ b/admin/src/main/java/com/reservation/admin/terms/service/mapper/TermsDtoMapper.java
@@ -30,7 +30,7 @@ public class TermsDtoMapper {
 	public static TermsDto fromUpdateTermsRequestAndVersion(UpdateTermsRequest request,
 		Integer version) {
 		return new TermsDto(
-			request.id(), // id
+			null, // id
 			request.code(),
 			request.title(),
 			request.type(),

--- a/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerMemberRepository.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerMemberRepository.java
@@ -1,0 +1,12 @@
+package com.reservation.commonapi.customer.repository;
+
+import com.reservation.commonmodel.member.MemberDto;
+import com.reservation.commonmodel.member.MemberStatus;
+
+public interface CustomerMemberRepository {
+	Boolean existsByPhoneNumberAndStatus(String phoneNumber, MemberStatus status); // 휴대폰 번호 중복 체크
+
+	Boolean existsByEmailAndStatus(String email, MemberStatus status); // 이메일 중복 체크
+
+	MemberDto save(MemberDto memberDto); // 고객 정보 저장
+}

--- a/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerTermsRepository.java
+++ b/common-api/src/main/java/com/reservation/commonapi/customer/repository/CustomerTermsRepository.java
@@ -8,11 +8,16 @@ import org.springframework.data.domain.Page;
 import com.reservation.commonapi.customer.query.CustomerTermsQueryCondition;
 import com.reservation.commonapi.customer.repository.dto.CustomerTermsDto;
 import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.commonmodel.terms.TermsStatus;
 
 public interface CustomerTermsRepository {
 	Page<CustomerTermsDto> findTermsByCondition(CustomerTermsQueryCondition condition); // Query Condition 조회
 
 	Optional<TermsDto> findById(Long id); // 약관 ID로 단일 조회
 
+	Optional<TermsDto> findWithClausesById(Long id); // 약관 ID로 단일 조회
+
 	List<TermsDto> findRequiredTerms();
+
+	List<TermsDto> findByStatusAndIsLatest(TermsStatus status, Boolean isLatest);
 }

--- a/common-model/src/main/java/com/reservation/commonmodel/member/MemberDto.java
+++ b/common-model/src/main/java/com/reservation/commonmodel/member/MemberDto.java
@@ -1,0 +1,16 @@
+package com.reservation.commonmodel.member;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MemberDto(
+	Long id,
+	String password,
+	MemberStatus status,
+	String email,
+	String phoneNumber,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt,
+	List<MemberTermsDto> memberTerms
+) {
+}

--- a/common-model/src/main/java/com/reservation/commonmodel/member/MemberStatus.java
+++ b/common-model/src/main/java/com/reservation/commonmodel/member/MemberStatus.java
@@ -1,0 +1,18 @@
+package com.reservation.commonmodel.member;
+
+public enum MemberStatus {
+	ACTIVE("정상 계정"),
+	INACTIVE("휴면 계정"),
+	SUSPENDED("정지 계정"),
+	WITHDRAWN("탈퇴 계정");
+
+	private final String label;
+
+	MemberStatus(String label) {
+		this.label = label;
+	}
+
+	public String label() {
+		return label;
+	}
+}

--- a/common-model/src/main/java/com/reservation/commonmodel/member/MemberTermsDto.java
+++ b/common-model/src/main/java/com/reservation/commonmodel/member/MemberTermsDto.java
@@ -1,0 +1,13 @@
+package com.reservation.commonmodel.member;
+
+import java.time.LocalDateTime;
+
+import com.reservation.commonmodel.terms.TermsDto;
+
+public record MemberTermsDto(
+	Boolean isAgreed,
+	LocalDateTime agreedAt,
+	MemberDto memberDto,
+	TermsDto termsDto
+) {
+}

--- a/common-model/src/main/java/com/reservation/commonmodel/terms/TermsCode.java
+++ b/common-model/src/main/java/com/reservation/commonmodel/terms/TermsCode.java
@@ -2,7 +2,10 @@ package com.reservation.commonmodel.terms;
 
 public enum TermsCode {
 	TERMS_USE("이용약관"),
-	TERMS_PRIVACY("개인정보처리방침");
+	TERMS_PRIVACY("개인정보처리방침"),
+	TERMS_MARKETING("마케팅정보 수집 및 이용 동의"),
+	TERMS_LOCATION("위치 정보 수집 및 이용 동의"),
+	;
 
 	private final String label;
 

--- a/common/src/main/java/com/reservation/common/clause/domain/Clause.java
+++ b/common/src/main/java/com/reservation/common/clause/domain/Clause.java
@@ -13,7 +13,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
-import lombok.ToString;
 
 /**
  * 약관 조항
@@ -27,7 +26,6 @@ import lombok.ToString;
 public class Clause extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "terms_id", nullable = false)
-	@ToString.Exclude
 	private Terms terms;
 
 	@Getter

--- a/common/src/main/java/com/reservation/common/domain/BaseEntity.java
+++ b/common/src/main/java/com/reservation/common/domain/BaseEntity.java
@@ -21,7 +21,7 @@ public abstract class BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	protected Long id;
 
 	@CreatedDate
 	@Column(updatable = false, nullable = false)

--- a/common/src/main/java/com/reservation/common/member/domain/Member.java
+++ b/common/src/main/java/com/reservation/common/member/domain/Member.java
@@ -1,0 +1,95 @@
+package com.reservation.common.member.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.reservation.common.domain.BaseEntity;
+import com.reservation.commonmodel.exception.ErrorCode;
+import com.reservation.commonmodel.member.MemberStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Transient;
+import lombok.Getter;
+
+@Entity
+public class Member extends BaseEntity {
+	@Column(nullable = false)
+	private String password;
+
+	@Getter
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MemberStatus status;
+
+	@Getter
+	@Column(nullable = false)
+	private String email;
+
+	@Getter
+	@Column(nullable = false)
+	private String phoneNumber;
+
+	@Getter
+	@Transient
+	private final List<MemberTerms> memberTermsList = new ArrayList<>();
+
+	protected Member() {
+	}
+
+	public Member(String password, MemberStatus status, String email, String phoneNumber) {
+		if (password == null || password.isEmpty()) {
+			throw ErrorCode.CONFLICT.exception("비빌 번호는 필수입니다.");
+		}
+		if (status == null) {
+			throw ErrorCode.CONFLICT.exception("상태는 필수입니다.");
+		}
+		if (email == null || email.isEmpty()) {
+			throw ErrorCode.CONFLICT.exception("이메일은 필수입니다.");
+		}
+		if (phoneNumber == null || phoneNumber.isEmpty()) {
+			throw ErrorCode.CONFLICT.exception("전화번호는 필수입니다.");
+		}
+		this.password = password;
+		this.status = status;
+		this.email = email;
+		this.phoneNumber = phoneNumber;
+	}
+
+	public static class MemberBuilder {
+		private String password;
+		private MemberStatus status;
+		private String email;
+		private String phoneNumber;
+
+		public MemberBuilder password(String password) {
+			this.password = password;
+			return this;
+		}
+
+		public MemberBuilder status(MemberStatus status) {
+			this.status = status;
+			return this;
+		}
+
+		public MemberBuilder email(String email) {
+			this.email = email;
+			return this;
+		}
+
+		public MemberBuilder phoneNumber(String phoneNumber) {
+			this.phoneNumber = phoneNumber;
+			return this;
+		}
+
+		public Member build() {
+			return new Member(password, status, email, phoneNumber);
+		}
+	}
+
+	public void addMemberTermsList(List<MemberTerms> memberTermsList) {
+		this.memberTermsList.addAll(memberTermsList);
+	}
+}

--- a/common/src/main/java/com/reservation/common/member/domain/MemberTerms.java
+++ b/common/src/main/java/com/reservation/common/member/domain/MemberTerms.java
@@ -1,0 +1,89 @@
+package com.reservation.common.member.domain;
+
+import java.time.LocalDateTime;
+
+import com.reservation.common.domain.BaseEntity;
+import com.reservation.common.terms.domain.Terms;
+import com.reservation.commonmodel.exception.ErrorCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+public class MemberTerms extends BaseEntity {
+	@Getter
+	@Column(nullable = false)
+	private Boolean isAgreed;
+
+	@Getter
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Getter
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "terms_id", nullable = false)
+	private Terms terms;
+
+	@Getter
+	@Column(nullable = false)
+	private LocalDateTime agreedAt;
+
+	protected MemberTerms() {
+	}
+
+	public MemberTerms(Boolean isAgreed, Member member, Terms terms, LocalDateTime agreedAt) {
+		if (isAgreed == null) {
+			throw ErrorCode.NOT_FOUND.exception("isAgreed는 필수입니다.");
+		}
+		if (agreedAt == null) {
+			throw ErrorCode.NOT_FOUND.exception("동의 일시는 필수입니다.");
+		}
+		if (terms == null) {
+			throw ErrorCode.NOT_FOUND.exception("약관은 필수입니다.");
+		}
+		if (member == null) {
+			throw ErrorCode.NOT_FOUND.exception("회원은 필수입니다.");
+		}
+
+		this.isAgreed = isAgreed;
+		this.member = member;
+		this.terms = terms;
+		this.agreedAt = agreedAt;
+	}
+
+	public static class MemberTermsBuilder {
+		private Boolean isAgreed;
+		private Member member;
+		private Terms terms;
+		private LocalDateTime agreedAt;
+
+		public MemberTermsBuilder isAgreed(Boolean isAgreed) {
+			this.isAgreed = isAgreed;
+			return this;
+		}
+
+		public MemberTermsBuilder member(Member member) {
+			this.member = member;
+			return this;
+		}
+
+		public MemberTermsBuilder terms(Terms terms) {
+			this.terms = terms;
+			return this;
+		}
+
+		public MemberTermsBuilder agreedAt(LocalDateTime agreedAt) {
+			this.agreedAt = agreedAt;
+			return this;
+		}
+
+		public MemberTerms build() {
+			return new MemberTerms(isAgreed, member, terms, agreedAt);
+		}
+	}
+}

--- a/common/src/main/java/com/reservation/common/member/repository/JpaMemberRepository.java
+++ b/common/src/main/java/com/reservation/common/member/repository/JpaMemberRepository.java
@@ -1,0 +1,12 @@
+package com.reservation.common.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.common.member.domain.Member;
+import com.reservation.commonmodel.member.MemberStatus;
+
+public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+	Boolean existsByPhoneNumberAndStatus(String phoneNumber, MemberStatus status);
+
+	Boolean existsByEmailAndStatus(String email, MemberStatus status);
+}

--- a/common/src/main/java/com/reservation/common/member/repository/MemberRepository.java
+++ b/common/src/main/java/com/reservation/common/member/repository/MemberRepository.java
@@ -1,0 +1,33 @@
+package com.reservation.common.member.repository;
+
+import static com.reservation.common.member.repository.mapper.MemberDtoMapper.*;
+
+import org.springframework.stereotype.Repository;
+
+import com.reservation.commonapi.customer.repository.CustomerMemberRepository;
+import com.reservation.commonmodel.member.MemberDto;
+import com.reservation.commonmodel.member.MemberStatus;
+
+@Repository
+public class MemberRepository implements CustomerMemberRepository {
+	private final JpaMemberRepository jpaMemberRepository;
+
+	public MemberRepository(JpaMemberRepository jpaMemberRepository) {
+		this.jpaMemberRepository = jpaMemberRepository;
+	}
+
+	@Override
+	public Boolean existsByPhoneNumberAndStatus(String phoneNumber, MemberStatus status) {
+		return jpaMemberRepository.existsByPhoneNumberAndStatus(phoneNumber, status);
+	}
+
+	@Override
+	public Boolean existsByEmailAndStatus(String email, MemberStatus status) {
+		return jpaMemberRepository.existsByEmailAndStatus(email, status);
+	}
+
+	@Override
+	public MemberDto save(MemberDto memberDto) {
+		return fromMember(jpaMemberRepository.save(toMember(memberDto)));
+	}
+}

--- a/common/src/main/java/com/reservation/common/member/repository/mapper/MemberDtoMapper.java
+++ b/common/src/main/java/com/reservation/common/member/repository/mapper/MemberDtoMapper.java
@@ -1,0 +1,54 @@
+package com.reservation.common.member.repository.mapper;
+
+import java.util.List;
+
+import com.reservation.common.member.domain.Member;
+import com.reservation.common.member.domain.Member.MemberBuilder;
+import com.reservation.common.member.domain.MemberTerms;
+import com.reservation.common.member.domain.MemberTerms.MemberTermsBuilder;
+import com.reservation.common.terms.repository.mapper.TermsDtoMapper;
+import com.reservation.commonmodel.member.MemberDto;
+import com.reservation.commonmodel.member.MemberTermsDto;
+
+public class MemberDtoMapper {
+	public static MemberDto fromMember(Member member) {
+		return new MemberDto(
+			member.getId(),
+			null,
+			member.getStatus(),
+			member.getEmail(),
+			member.getPhoneNumber(),
+			member.getCreatedAt(),
+			member.getUpdatedAt(),
+			member.getMemberTermsList()
+				.stream()
+				.map((memberTerms) ->
+					new MemberTermsDto(memberTerms.getIsAgreed(), memberTerms.getAgreedAt(), null, null))
+				.toList()
+		);
+	}
+
+	public static Member toMember(MemberDto memberDto) {
+		Member member = new MemberBuilder()
+			.email(memberDto.email())
+			.phoneNumber(memberDto.phoneNumber())
+			.password(memberDto.password())
+			.status(memberDto.status())
+			.build();
+
+		List<MemberTerms> memberTermsList = memberDto.memberTerms()
+			.stream()
+			.map((memberTermsDto) ->
+				new MemberTermsBuilder()
+					.terms(TermsDtoMapper.ToTerms(memberTermsDto.termsDto()))
+					.member(member)
+					.agreedAt(memberTermsDto.agreedAt())
+					.isAgreed(memberTermsDto.isAgreed())
+					.build())
+			.toList();
+
+		member.addMemberTermsList(memberTermsList);
+
+		return member;
+	}
+}

--- a/common/src/main/java/com/reservation/common/response/ApiResponse.java
+++ b/common/src/main/java/com/reservation/common/response/ApiResponse.java
@@ -7,5 +7,9 @@ public record ApiResponse<T>(
 	public static <T> ApiResponse<T> ok(T data) {
 		return new ApiResponse<>(true, data);
 	}
+
+	public static <T> ApiResponse<T> noContent() {
+		return new ApiResponse<>(true, null);
+	}
 }
 

--- a/common/src/main/java/com/reservation/common/terms/domain/Terms.java
+++ b/common/src/main/java/com/reservation/common/terms/domain/Terms.java
@@ -18,12 +18,10 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
-import lombok.ToString;
 
 @Entity
 @Table(
@@ -73,7 +71,6 @@ public class Terms extends BaseEntity {
 	private Integer displayOrder; // 정렬 순서
 
 	@OneToMany(mappedBy = "terms", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-	@ToString.Exclude
 	private final List<Clause> clauseList = new ArrayList<>();
 
 	@Transient
@@ -82,9 +79,8 @@ public class Terms extends BaseEntity {
 	protected Terms() {
 	}
 
-	private Terms(TermsCode code, String title, TermsType type, TermsStatus status, Integer version, Boolean isLatest,
-		LocalDateTime exposedFrom,
-		LocalDateTime exposedToOrNull, Integer displayOrder) {
+	private Terms(Long id, TermsCode code, String title, TermsType type, TermsStatus status, Integer version,
+		Boolean isLatest, LocalDateTime exposedFrom, LocalDateTime exposedToOrNull, Integer displayOrder) {
 		if (code == null) {
 			throw ErrorCode.CONFLICT.exception("약관 코드는 필수입니다.");
 		}
@@ -112,6 +108,7 @@ public class Terms extends BaseEntity {
 		if (exposedToOrNull != null && exposedFrom.isAfter(exposedToOrNull)) {
 			throw ErrorCode.CONFLICT.exception("노출 종료일은 노출 시작일보다 늦어야 합니다.");
 		}
+		this.id = id;
 		this.code = code;
 		this.title = title;
 		this.type = type;
@@ -124,6 +121,7 @@ public class Terms extends BaseEntity {
 	}
 
 	public static class TermsBuilder {
+		private Long id;
 		private TermsCode code;
 		private String title;
 		private TermsType type;
@@ -133,6 +131,11 @@ public class Terms extends BaseEntity {
 		private LocalDateTime exposedFrom;
 		private LocalDateTime exposedToOrNull;
 		private Integer displayOrder;
+
+		public TermsBuilder id(Long id) {
+			this.id = id;
+			return this;
+		}
 
 		public TermsBuilder code(TermsCode code) {
 			this.code = code;
@@ -180,13 +183,9 @@ public class Terms extends BaseEntity {
 		}
 
 		public Terms build() {
-			return new Terms(code, title, type, status, version, isLatest, exposedFrom, exposedToOrNull, displayOrder);
+			return new Terms(id, code, title, type, status, version, isLatest, exposedFrom, exposedToOrNull,
+				displayOrder);
 		}
-	}
-
-	@PostLoad
-	private void onLoad() {
-		this.clauses = new Clauses(this.clauseList);
 	}
 
 	public Clauses getClauses() {

--- a/common/src/main/java/com/reservation/common/terms/repository/JpaTermsRepository.java
+++ b/common/src/main/java/com/reservation/common/terms/repository/JpaTermsRepository.java
@@ -20,4 +20,6 @@ public interface JpaTermsRepository extends JpaRepository<Terms, Long> {
 	Optional<Integer> findMaxVersionByCode(@Param("code") TermsCode code);
 
 	List<Terms> findByTypeAndStatus(TermsType termsType, TermsStatus termsStatus);
+
+	List<Terms> findByStatusAndIsLatest(TermsStatus termsStatus, Boolean isLatest);
 }

--- a/common/src/main/java/com/reservation/common/terms/repository/TermsRepository.java
+++ b/common/src/main/java/com/reservation/common/terms/repository/TermsRepository.java
@@ -1,6 +1,7 @@
 package com.reservation.common.terms.repository;
 
 import static com.reservation.common.support.sort.SortUtils.*;
+import static com.reservation.common.terms.repository.mapper.TermsDtoMapper.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -50,7 +51,7 @@ public class TermsRepository implements AdminTermsRepository, CustomerTermsRepos
 	@Override
 	public TermsDto save(TermsDto termsDto) {
 		Terms terms = TermsDtoMapper.ToTerms(termsDto);
-		return TermsDtoMapper.fromTerms(jpaTermsRepository.save(terms));
+		return fromTerms(jpaTermsRepository.save(terms), false);
 	}
 
 	@Override
@@ -65,14 +66,22 @@ public class TermsRepository implements AdminTermsRepository, CustomerTermsRepos
 
 	@Override
 	public Optional<TermsDto> findById(Long id) {
-		return this.jpaTermsRepository.findById(id).map(TermsDtoMapper::fromTerms);
+		return this.jpaTermsRepository.findById(id).map((terms) -> fromTerms(terms, true));
 	}
 
 	@Override
 	public List<TermsDto> findRequiredTerms() {
 		return this.jpaTermsRepository.findByTypeAndStatus(TermsType.REQUIRED, TermsStatus.ACTIVE)
 			.stream()
-			.map(TermsDtoMapper::fromTerms)
+			.map((terms) -> fromTerms(terms, false))
+			.toList();
+	}
+
+	@Override
+	public List<TermsDto> findByStatusAndIsLatest(TermsStatus status, Boolean isLatest) {
+		return this.jpaTermsRepository.findByStatusAndIsLatest(status, isLatest)
+			.stream()
+			.map((terms) -> fromTerms(terms, false))
 			.toList();
 	}
 
@@ -192,7 +201,7 @@ public class TermsRepository implements AdminTermsRepository, CustomerTermsRepos
 			.where(terms.id.eq(id))
 			.fetchOne();
 		Optional<Terms> optionalResult = Optional.ofNullable(result);
-		return optionalResult.map(TermsDtoMapper::fromTerms);
+		return optionalResult.map((terms) -> fromTerms(terms, true));
 	}
 
 	@Override

--- a/common/src/main/java/com/reservation/common/terms/repository/mapper/TermsDtoMapper.java
+++ b/common/src/main/java/com/reservation/common/terms/repository/mapper/TermsDtoMapper.java
@@ -3,17 +3,18 @@ package com.reservation.common.terms.repository.mapper;
 import java.util.List;
 
 import com.reservation.common.clause.domain.Clause;
+import com.reservation.common.clause.domain.Clause.ClauseBuilder;
 import com.reservation.common.terms.domain.Clauses;
 import com.reservation.common.terms.domain.Terms;
 import com.reservation.commonmodel.terms.ClauseDto;
 import com.reservation.commonmodel.terms.TermsDto;
 
 public class TermsDtoMapper {
-	public static TermsDto fromTerms(Terms terms) {
-		List<ClauseDto> adminClauses = terms.getClauses()
+	public static TermsDto fromTerms(Terms terms, boolean isClauses) {
+		List<ClauseDto> adminClauses = isClauses ? terms.getClauses()
 			.stream()
 			.map(c -> new ClauseDto(c.getId(), c.getClauseOrder(), c.getTitle(), c.getContent()))
-			.toList();
+			.toList() : null;
 
 		return new TermsDto(
 			terms.getId(),
@@ -32,7 +33,9 @@ public class TermsDtoMapper {
 	}
 
 	public static Terms ToTerms(TermsDto termsDto) {
+		System.out.println("termsDto = " + termsDto);
 		Terms terms = new Terms.TermsBuilder()
+			.id(termsDto.id())
 			.code(termsDto.code())
 			.title(termsDto.title())
 			.type(termsDto.type())
@@ -44,16 +47,18 @@ public class TermsDtoMapper {
 			.displayOrder(termsDto.displayOrder())
 			.build();
 
-		List<Clause> clauses = termsDto.clauses().stream()
-			.map(dto -> new Clause.ClauseBuilder()
-				.terms(terms)
-				.clauseOrder(dto.clauseOrder())
-				.title(dto.title())
-				.content(dto.content())
-				.build())
-			.toList();
+		if (termsDto.clauses() != null) {
+			List<Clause> clauses = termsDto.clauses().stream()
+				.map(dto -> new ClauseBuilder()
+					.terms(terms)
+					.clauseOrder(dto.clauseOrder())
+					.title(dto.title())
+					.content(dto.content())
+					.build())
+				.toList();
 
-		terms.setClauses(new Clauses(clauses));
+			terms.setClauses(new Clauses(clauses));
+		}
 
 		return terms;
 	}

--- a/common/src/test/java/com/reservation/common/clause/domain/ClauseTest.java
+++ b/common/src/test/java/com/reservation/common/clause/domain/ClauseTest.java
@@ -34,7 +34,6 @@ public class ClauseTest {
 			.build();
 
 		assertNotNull(clause);
-		assertEquals(terms, clause.getTerms());
 		assertEquals(1, clause.getClauseOrder());
 		assertEquals("제1조 (목적)", clause.getTitle());
 		assertEquals("이 약관은...", clause.getContent());

--- a/common/src/test/java/com/reservation/common/terms/domain/TermsTest.java
+++ b/common/src/test/java/com/reservation/common/terms/domain/TermsTest.java
@@ -64,9 +64,7 @@ public class TermsTest {
 
 		terms.setClauses(clauses);
 
-		assertNotNull(terms.getClauseList());
-		assertEquals(1, terms.getClauseList().size());
-		assertEquals(clause, terms.getClauseList().getFirst());
+		assertNotNull(terms.getClauses());
 		assertDoesNotThrow(terms::validateComplete);
 	}
 

--- a/customer/build.gradle
+++ b/customer/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.security:spring-security-crypto:6.4.4'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/customer/src/main/java/com/reservation/customer/config/SecurityConfig.java
+++ b/customer/src/main/java/com/reservation/customer/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.reservation.customer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/member/controller/MemberController.java
+++ b/customer/src/main/java/com/reservation/customer/member/controller/MemberController.java
@@ -1,0 +1,32 @@
+package com.reservation.customer.member.controller;
+
+import static com.reservation.common.response.ApiResponse.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reservation.common.response.ApiResponse;
+import com.reservation.customer.member.controller.dto.request.SignupRequest;
+import com.reservation.customer.member.service.MemberService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("member")
+@Tag(name = "일반 회원 관리 API", description = "일반 회원 관리 API입니다.")
+@RequiredArgsConstructor
+public class MemberController {
+	private final MemberService memberService;
+
+	@PostMapping("/signup")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public ApiResponse<Void> signup(@RequestBody SignupRequest request) {
+		memberService.signup(request);
+		return noContent();
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/member/controller/dto/request/SignupRequest.java
+++ b/customer/src/main/java/com/reservation/customer/member/controller/dto/request/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.reservation.customer.member.controller.dto.request;
+
+import jakarta.annotation.Nonnull;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignupRequest(
+	@Nonnull @Pattern(regexp = "^01[016789]-?\\d{3,4}-?\\d{4}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	String phoneNumber,
+	@Nonnull @Email
+	String email,
+	@NotBlank
+	String password) {
+}

--- a/customer/src/main/java/com/reservation/customer/member/service/MemberService.java
+++ b/customer/src/main/java/com/reservation/customer/member/service/MemberService.java
@@ -1,0 +1,113 @@
+package com.reservation.customer.member.service;
+
+import static com.reservation.customer.member.service.mapper.MemberDtoMapper.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.commonapi.customer.repository.CustomerMemberRepository;
+import com.reservation.commonapi.customer.repository.CustomerTermsRepository;
+import com.reservation.commonmodel.exception.ErrorCode;
+import com.reservation.commonmodel.member.MemberDto;
+import com.reservation.commonmodel.member.MemberStatus;
+import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.commonmodel.terms.TermsStatus;
+import com.reservation.commonmodel.terms.TermsType;
+import com.reservation.customer.member.controller.dto.request.SignupRequest;
+import com.reservation.customer.phoneverification.service.dto.PhoneVerifiedRedisValue;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class MemberService {
+	private static final String PHONE_VERIFIED_KEY_PREFIX = "phone:verified:";
+
+	private final CustomerMemberRepository memberRepository;
+	private final CustomerTermsRepository termsRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+	private final PasswordEncoder passwordEncoder;
+
+	public void signup(SignupRequest request) {
+		// verifiedKey: 핸드폰 인증
+		String phoneNumber = request.phoneNumber().replaceAll("-", "");
+		String key = PHONE_VERIFIED_KEY_PREFIX + phoneNumber;
+		List<Long> acceptedTermsIds = checkVerifiedKey(key);
+
+		// 약관 동의 체크
+		List<TermsDto> checkTermsList = checkTermsList(acceptedTermsIds);
+
+		// 중복 가입 체크
+		checkDuplicateMember(request.email(), phoneNumber);
+
+		// Customer 저장
+		// 패스워드 저장 시 BCrypt
+		String encryptedPassword = passwordEncoder.encode(request.password());
+		MemberDto memberDto = fromSignupRequestAndPasswordAndTermsDtoList(request, encryptedPassword, checkTermsList);
+		memberRepository.save(memberDto);
+
+		// verifiedKey: 핸드폰 인증 내역 삭제
+		redisTemplate.delete(key);
+	}
+
+	private List<Long> checkVerifiedKey(String key) {
+		ValueOperations<String, String> ops = redisTemplate.opsForValue();
+		String redisJson = ops.get(key);
+
+		if (redisJson == null || redisJson.isEmpty()) {
+			throw ErrorCode.CONFLICT.exception("핸드폰 인증이 확인되지 않습니다. 다시 시도해주세요.");
+		}
+
+		try {
+			PhoneVerifiedRedisValue phoneVerifiedRedisValue = objectMapper.readValue(redisJson,
+				PhoneVerifiedRedisValue.class);
+			return phoneVerifiedRedisValue.agreedTermsIds().stream().toList();
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage(), e);
+			throw ErrorCode.CONFLICT.exception("핸드폰 인증 확인에 실패했습니다. 다시 시도해주세요.");
+		}
+	}
+
+	private List<TermsDto> checkTermsList(List<Long> acceptedTermsIds) {
+		List<TermsDto> checkTermsList = new ArrayList<>();
+
+		List<TermsDto> latestTermsList = termsRepository.findByStatusAndIsLatest(TermsStatus.ACTIVE, true);
+		if (latestTermsList.isEmpty()) {
+			throw ErrorCode.INTERNAL_SERVER_ERROR.exception("약관 정보가 없습니다.");
+		}
+		
+		for (TermsDto latestTerms : latestTermsList) {
+			if (latestTerms.type() == TermsType.REQUIRED && !acceptedTermsIds.contains(latestTerms.id())) {
+				throw ErrorCode.CONFLICT.exception("필수 약관 정보에 동의하지 않았습니다.");
+			}
+			if (acceptedTermsIds.contains(latestTerms.id())) {
+				checkTermsList.add(latestTerms);
+			}
+		}
+
+		if (checkTermsList.size() != acceptedTermsIds.size()) {
+			throw ErrorCode.CONFLICT.exception("약관 정보가 올바르지 않습니다.");
+		}
+
+		return checkTermsList;
+	}
+
+	private void checkDuplicateMember(String email, String phoneNumber) {
+		if (memberRepository.existsByEmailAndStatus(email, MemberStatus.ACTIVE)) {
+			throw ErrorCode.CONFLICT.exception("이미 가입된 이메일입니다.");
+		}
+		if (memberRepository.existsByPhoneNumberAndStatus(phoneNumber, MemberStatus.ACTIVE)) {
+			throw ErrorCode.CONFLICT.exception("이미 가입된 핸드폰 번호입니다.");
+		}
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/member/service/mapper/MemberDtoMapper.java
+++ b/customer/src/main/java/com/reservation/customer/member/service/mapper/MemberDtoMapper.java
@@ -1,0 +1,28 @@
+package com.reservation.customer.member.service.mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.reservation.commonmodel.member.MemberDto;
+import com.reservation.commonmodel.member.MemberStatus;
+import com.reservation.commonmodel.member.MemberTermsDto;
+import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.customer.member.controller.dto.request.SignupRequest;
+
+public class MemberDtoMapper {
+	public static MemberDto fromSignupRequestAndPasswordAndTermsDtoList(SignupRequest request, String password,
+		List<TermsDto> termsDtoList) {
+		LocalDateTime now = LocalDateTime.now();
+		return new MemberDto(
+			null,
+			password,
+			MemberStatus.ACTIVE,
+			request.email(),
+			request.phoneNumber().replaceAll("-", ""),
+			null,
+			null,
+			termsDtoList.stream().map(termsDto ->
+				new MemberTermsDto(true, now, null, termsDto)).toList()
+		);
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/phoneverification/service/PhoneVerificationService.java
+++ b/customer/src/main/java/com/reservation/customer/phoneverification/service/PhoneVerificationService.java
@@ -20,6 +20,7 @@ import com.reservation.customer.phoneverification.controller.dto.request.VerifyP
 import com.reservation.customer.phoneverification.controller.dto.response.SendPhoneVerificationResponse;
 import com.reservation.customer.phoneverification.controller.dto.response.VerifyPhoneVerificationResponse;
 import com.reservation.customer.phoneverification.service.dto.PhoneVerificationRedisValue;
+import com.reservation.customer.phoneverification.service.dto.PhoneVerifiedRedisValue;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -138,7 +139,7 @@ public class PhoneVerificationService {
 		String key = PHONE_VERIFIED_KEY_PREFIX + phoneNumber;
 		ValueOperations<String, String> ops = redisTemplate.opsForValue();
 		try {
-			String redisJson = objectMapper.writeValueAsString(agreedTermsIds);
+			String redisJson = objectMapper.writeValueAsString(new PhoneVerifiedRedisValue(agreedTermsIds));
 			ops.set(key, redisJson, Duration.ofMinutes(VERIFIED_EXPIRES_TIME_MINUTES));
 		} catch (JsonProcessingException e) {
 			log.error(e.getMessage(), e);

--- a/customer/src/main/java/com/reservation/customer/phoneverification/service/dto/PhoneVerifiedRedisValue.java
+++ b/customer/src/main/java/com/reservation/customer/phoneverification/service/dto/PhoneVerifiedRedisValue.java
@@ -1,0 +1,6 @@
+package com.reservation.customer.phoneverification.service.dto;
+
+import java.util.Set;
+
+public record PhoneVerifiedRedisValue(Set<Long> agreedTermsIds) {
+}

--- a/customer/src/main/java/com/reservation/customer/terms/controller/dto/request/TermsSearchCondition.java
+++ b/customer/src/main/java/com/reservation/customer/terms/controller/dto/request/TermsSearchCondition.java
@@ -30,7 +30,7 @@ public record TermsSearchCondition(
 	@Schema(hidden = true)
 	@Override
 	public Sort.Order getDefaultSortOrder() {
-		return new Sort.Order(Sort.Direction.DESC, CustomerTermsSortField.DISPLAY_ORDER.getFieldName());
+		return new Sort.Order(Sort.Direction.ASC, CustomerTermsSortField.DISPLAY_ORDER.getFieldName());
 	}
 
 	@Schema(hidden = true)

--- a/customer/src/main/java/com/reservation/customer/terms/service/TermsService.java
+++ b/customer/src/main/java/com/reservation/customer/terms/service/TermsService.java
@@ -31,7 +31,7 @@ public class TermsService {
 	}
 
 	public TermsDetailResponse findById(Long id) {
-		TermsDto termsDto = this.termsRepository.findById(id)
+		TermsDto termsDto = this.termsRepository.findWithClausesById(id)
 			.orElseThrow(() -> ErrorCode.NOT_FOUND.exception("존재하지 않는 약관입니다."));
 
 		if (!termsDto.isLatest()) {

--- a/customer/src/test/java/com/reservation/customer/member/service/MemberServiceTest.java
+++ b/customer/src/test/java/com/reservation/customer/member/service/MemberServiceTest.java
@@ -1,0 +1,4 @@
+package com.reservation.customer.member.service;
+
+public class MemberServiceTest {
+}

--- a/customer/src/test/java/com/reservation/customer/member/service/MemberServiceTest.java
+++ b/customer/src/test/java/com/reservation/customer/member/service/MemberServiceTest.java
@@ -1,4 +1,321 @@
 package com.reservation.customer.member.service;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.commonapi.customer.repository.CustomerMemberRepository;
+import com.reservation.commonapi.customer.repository.CustomerTermsRepository;
+import com.reservation.commonmodel.exception.BusinessException;
+import com.reservation.commonmodel.member.MemberDto;
+import com.reservation.commonmodel.member.MemberStatus;
+import com.reservation.commonmodel.terms.ClauseDto;
+import com.reservation.commonmodel.terms.TermsCode;
+import com.reservation.commonmodel.terms.TermsDto;
+import com.reservation.commonmodel.terms.TermsStatus;
+import com.reservation.commonmodel.terms.TermsType;
+import com.reservation.customer.member.controller.dto.request.SignupRequest;
+import com.reservation.customer.phoneverification.service.dto.PhoneVerifiedRedisValue;
+
+@ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
+
+	@Mock
+	private CustomerMemberRepository memberRepository;
+
+	@Mock
+	private CustomerTermsRepository termsRepository;
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	private MemberService memberService;
+
+	private SignupRequest signupRequest;
+	private PhoneVerifiedRedisValue phoneVerifiedRedisValue;
+	private ValueOperations<String, String> valueOperations;
+
+	@BeforeEach
+	void setUp() {
+		signupRequest = new SignupRequest("010-1234-5678", "test@example.com", "password123");
+		phoneVerifiedRedisValue = new PhoneVerifiedRedisValue(Set.of(1L, 2L));
+		valueOperations = mock(ValueOperations.class);
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+	}
+
+	@Test
+	@DisplayName("회원가입 성공")
+	void signup_Success() throws JsonProcessingException {
+		String phoneNumber = "01012345678";
+		String key = "phone:verified:" + phoneNumber;
+
+		when(valueOperations.get(key)).thenReturn("{\"agreedTermsIds\":[1,2]}");
+		when(objectMapper.readValue(anyString(), eq(PhoneVerifiedRedisValue.class))).thenReturn(
+			phoneVerifiedRedisValue);
+
+		when(termsRepository.findByStatusAndIsLatest(TermsStatus.ACTIVE, true)).thenReturn(List.of(
+			new TermsDto(
+				1L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			),
+			new TermsDto(
+				2L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			)
+		));
+
+		when(memberRepository.existsByEmailAndStatus(signupRequest.email(), MemberStatus.ACTIVE)).thenReturn(false);
+		when(memberRepository.existsByPhoneNumberAndStatus(phoneNumber, MemberStatus.ACTIVE)).thenReturn(false);
+
+		when(passwordEncoder.encode(signupRequest.password())).thenReturn("encryptedPassword");
+
+		memberService.signup(signupRequest);
+
+		verify(memberRepository).save(any(MemberDto.class));
+		verify(redisTemplate).delete(key);
+	}
+
+	@Test
+	@DisplayName("핸드폰 인증 확인 실패")
+	void signup_ThrowsExceptionWhenPhoneVerificationFails() {
+		String phoneNumber = "01012345678";
+		String key = "phone:verified:" + phoneNumber;
+
+		// ValueOperations를 mock으로 설정
+		ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+		// Redis에서 key 조회 시 null 반환하도록 설정
+		when(valueOperations.get(key)).thenReturn(null);
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			memberService.signup(signupRequest);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("핸드폰 인증이 확인되지 않습니다. 다시 시도해주세요.");
+	}
+
+	@Test
+	@DisplayName("필수 약관 동의 실패")
+	void signup_ThrowsExceptionWhenRequiredTermsNotAgreed() throws JsonProcessingException {
+		String phoneNumber = "01012345678";
+		String key = "phone:verified:" + phoneNumber;
+
+		when(valueOperations.get(key)).thenReturn("{\"agreedTermsIds\":[2]}");
+		when(objectMapper.readValue(anyString(), eq(PhoneVerifiedRedisValue.class))).thenReturn(
+			phoneVerifiedRedisValue);
+
+		when(termsRepository.findByStatusAndIsLatest(TermsStatus.ACTIVE, true)).thenReturn(List.of(
+			new TermsDto(
+				1L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			),
+			new TermsDto(
+				3L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			)
+		));
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			memberService.signup(signupRequest);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("필수 약관 정보에 동의하지 않았습니다.");
+	}
+
+	@Test
+	@DisplayName("중복 이메일로 인한 회원가입 실패")
+	void signup_ThrowsExceptionWhenEmailAlreadyExists() throws JsonProcessingException {
+		String phoneNumber = "01012345678";
+		String key = "phone:verified:" + phoneNumber;
+
+		when(valueOperations.get(key)).thenReturn("{\"agreedTermsIds\":[1,2]}");
+		when(objectMapper.readValue(anyString(), eq(PhoneVerifiedRedisValue.class))).thenReturn(
+			phoneVerifiedRedisValue);
+
+		when(termsRepository.findByStatusAndIsLatest(TermsStatus.ACTIVE, true)).thenReturn(List.of(
+			new TermsDto(
+				1L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			),
+			new TermsDto(
+				2L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			)
+		));
+
+		when(memberRepository.existsByEmailAndStatus(signupRequest.email(), MemberStatus.ACTIVE)).thenReturn(true);
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			memberService.signup(signupRequest);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("이미 가입된 이메일입니다.");
+	}
+
+	@Test
+	@DisplayName("중복 핸드폰 번호로 인한 회원가입 실패")
+	void signup_ThrowsExceptionWhenPhoneNumberAlreadyExists() throws JsonProcessingException {
+		String phoneNumber = "01012345678";
+		String key = "phone:verified:" + phoneNumber;
+
+		when(valueOperations.get(key)).thenReturn("{\"agreedTermsIds\":[1,2]}");
+		when(objectMapper.readValue(anyString(), eq(PhoneVerifiedRedisValue.class))).thenReturn(
+			phoneVerifiedRedisValue);
+
+		when(termsRepository.findByStatusAndIsLatest(TermsStatus.ACTIVE, true)).thenReturn(List.of(
+			new TermsDto(
+				1L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			),
+			new TermsDto(
+				2L,
+				TermsCode.TERMS_USE,
+				"서비스 이용약관",
+				TermsType.REQUIRED,
+				TermsStatus.ACTIVE,
+				1,
+				false, // isLatest가 false
+				LocalDateTime.of(2025, 3, 25, 0, 0),
+				LocalDateTime.of(2026, 3, 25, 0, 0),
+				1,
+				null,
+				null,
+				List.of(
+					new ClauseDto(1L, 1, "제1조 (목적)", "이 약관은..."),
+					new ClauseDto(2L, 2, "제2조 (이용)", "이 약관은...")
+				)
+			)
+		));
+
+		when(memberRepository.existsByPhoneNumberAndStatus(phoneNumber, MemberStatus.ACTIVE)).thenReturn(true);
+
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			memberService.signup(signupRequest);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("이미 가입된 핸드폰 번호입니다.");
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #40 

## 📝작업 내용

1. 핸드폰 인증 내역 확인  및 약관 동의 내역 검증 
2. 중복 가입 방지
3. 비밀 번호 암호화
4. 회원 가입 로직 테스트 작성
 

### 스크린샷 (선택)

- API 문서

<img width="800" alt="image" src="https://github.com/user-attachments/assets/5acbc931-b78d-4a58-b3ee-79ac6304fbcb" />

- 회원 > 동의한 약관 관리 관계도

<img width="400" alt="image" src="https://github.com/user-attachments/assets/1731ef4f-276b-4c64-a442-794b35c513c2" />

## 💬리뷰 요구사항(선택)

- 약관 동의 내역은 핸드폰 인증 번호 확인 과정에서 Redis에 저장된 약관 동의 내역을 조회합니다 (TTL 10분)
- 회원 가입 API 요청 시점에 ACTIVE 상태 이면서, 최신 버전이 맞는 약관을 모두 조회하여 회원이 동의한 약관을 검증합니다
- 핸드폰, 이메일로 중복 가입 체크를 합니다
- 패스워드는 암호화하여 저장합니다
- 기존 핸드폰 인증 확인 내역을 삭제합니다