### PR TITLE
AccessToken 재발급 API 개발

### DIFF
--- a/common-auth/src/main/java/com/reservation/commonauth/auth/filter/JwtAuthenticationFilter.java
+++ b/common-auth/src/main/java/com/reservation/commonauth/auth/filter/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.reservation.commonauth.auth;
+package com.reservation.commonauth.auth.filter;
 
 import java.io.IOException;
 import java.util.List;
@@ -8,6 +8,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.reservation.commonauth.auth.token.JwtTokenProvider;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/common-auth/src/main/java/com/reservation/commonauth/auth/token/JwtTokenProvider.java
+++ b/common-auth/src/main/java/com/reservation/commonauth/auth/token/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.reservation.commonauth.auth;
+package com.reservation.commonauth.auth.token;
 
 import java.util.Date;
 

--- a/customer/src/main/java/com/reservation/customer/auth/controller/AuthController.java
+++ b/customer/src/main/java/com/reservation/customer/auth/controller/AuthController.java
@@ -23,6 +23,7 @@ import com.reservation.customer.auth.controller.dto.request.LoginRequest;
 import com.reservation.customer.auth.service.AuthService;
 import com.reservation.customer.auth.service.dto.LoginDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -60,13 +61,14 @@ public class AuthController {
 
 	@GetMapping("/me")
 	@PreAuthorize(PRE_AUTH_ROLE_CUSTOMER)
-	public ApiResponse<MemberDto> getMe(@LoginMember Long memberId) {
+	public ApiResponse<MemberDto> getMe(@Schema(hidden = true) @LoginMember Long memberId) {
 		return ok(authService.findMe(memberId));
 	}
 
 	@GetMapping("/token/refresh")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@PreAuthorize(PRE_AUTH_ROLE_CUSTOMER)
-	public ResponseEntity<Void> tokenReissue(@LoginMember Long memberId) {
+	public ResponseEntity<Void> tokenReissue(@Schema(hidden = true) @LoginMember Long memberId) {
 		String accessToken = authService.tokenReissue(memberId);
 
 		return ResponseEntity.noContent()

--- a/customer/src/main/java/com/reservation/customer/auth/service/AuthService.java
+++ b/customer/src/main/java/com/reservation/customer/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.reservation.customer.auth.service;
 
-import static com.reservation.commonauth.auth.JwtTokenProvider.*;
+import static com.reservation.commonauth.auth.token.JwtTokenProvider.*;
+import static com.reservation.customer.auth.controller.AuthController.*;
 
 import java.time.Duration;
 
@@ -9,12 +10,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.reservation.commonapi.customer.repository.CustomerMemberRepository;
-import com.reservation.commonauth.auth.JwtTokenProvider;
+import com.reservation.commonauth.auth.token.JwtTokenProvider;
 import com.reservation.commonmodel.exception.ErrorCode;
 import com.reservation.commonmodel.member.MemberDto;
 import com.reservation.commonmodel.member.MemberStatus;
 import com.reservation.customer.auth.controller.dto.request.LoginRequest;
 import com.reservation.customer.auth.service.dto.LoginDto;
+import com.reservation.customer.auth.token.RequestContext;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -28,6 +30,7 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final PasswordEncoder passwordEncoder;
+	private final RequestContext requestContext;
 
 	public LoginDto login(LoginRequest request) {
 		MemberDto memberDto = memberRepository.findOneByEmailAndStatusIsNot(request.email(), MemberStatus.WITHDRAWN);
@@ -41,14 +44,14 @@ public class AuthService {
 			throw ErrorCode.NOT_FOUND.exception("로그인 정보가 일치하지 않습니다.");
 		}
 
-		String accessToken = jwtTokenProvider.generateToken(memberDto.id(), "ROLE_CUSTOMER");
+		String accessToken = jwtTokenProvider.generateToken(memberDto.id(), ROLE_CUSTOMER);
 		String refreshToken = storeRefreshToken(memberDto.id());
 
 		return new LoginDto(memberDto.id(), accessToken, refreshToken);
 	}
 
 	private String storeRefreshToken(Long memberId) {
-		String refreshToken = jwtTokenProvider.generateRefreshToken(memberId, "ROLE_CUSTOMER");
+		String refreshToken = jwtTokenProvider.generateRefreshToken(memberId, ROLE_CUSTOMER);
 		String key = REFRESH_TOKEN_PREFIX + memberId;
 		redisTemplate.opsForValue().set(key, refreshToken, Duration.ofMinutes(REFRESH_TOKEN_VALIDITY_IN_MILLIS));
 		return refreshToken;
@@ -56,5 +59,24 @@ public class AuthService {
 
 	public MemberDto findMe(Long memberId) {
 		return memberRepository.findById(memberId);
+	}
+
+	public String tokenReissue(Long memberId) {
+		String key = REFRESH_TOKEN_PREFIX + memberId;
+		String redisToken = redisTemplate.opsForValue().get(key);
+		if (redisToken == null || redisToken.isBlank()) {
+			throw ErrorCode.UNAUTHORIZED.exception("로그인 정보가 만료되었습니다.");
+		}
+
+		String refreshToken = requestContext.getRefreshToken();
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw ErrorCode.UNAUTHORIZED.exception("로그인 정보가 만료되었습니다.");
+		}
+
+		if (!redisToken.equals(refreshToken)) {
+			throw ErrorCode.UNAUTHORIZED.exception("인증 정보가 일치하지 않습니다.");
+		}
+
+		return jwtTokenProvider.generateToken(memberId, ROLE_CUSTOMER);
 	}
 }

--- a/customer/src/main/java/com/reservation/customer/auth/token/RequestContext.java
+++ b/customer/src/main/java/com/reservation/customer/auth/token/RequestContext.java
@@ -1,0 +1,36 @@
+package com.reservation.customer.auth.token;
+
+import static com.reservation.customer.auth.controller.AuthController.*;
+import static org.springframework.context.annotation.ScopedProxyMode.*;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequestScope(proxyMode = TARGET_CLASS)
+@RequiredArgsConstructor
+public class RequestContext {
+	private final HttpServletRequest request;
+
+	public String getRefreshToken() {
+		return getCookie(REFRESH_COOKIE_NAME);
+	}
+
+	public String getCookie(String name) {
+		if (request.getCookies() == null) {
+			return null;
+		}
+
+		return Arrays.stream(request.getCookies())
+			.filter(c -> c.getName().equals(name))
+			.map(Cookie::getValue)
+			.findFirst()
+			.orElse(null);
+	}
+}

--- a/customer/src/main/java/com/reservation/customer/config/SecurityConfig.java
+++ b/customer/src/main/java/com/reservation/customer/config/SecurityConfig.java
@@ -14,8 +14,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.reservation.commonauth.auth.JwtAuthenticationFilter;
-import com.reservation.commonauth.auth.JwtTokenProvider;
+import com.reservation.commonauth.auth.filter.JwtAuthenticationFilter;
+import com.reservation.commonauth.auth.token.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #44 

## 📝작업 내용

1. Reuse 전략 채택
3. 리프레쉬 토큰 쿠키 검증 및 AccessToken 재발급
4. Http Cookie 추출을 위한 RequestContext 구현

### 스크린샷 (선택)

- API 문서

<img width="800" alt="image" src="https://github.com/user-attachments/assets/97ff8035-4238-481a-a31b-6057fdfbff54" />


- 토큰 재발급 확인

<img width="800" alt="image" src="https://github.com/user-attachments/assets/6b680e4d-a735-4241-9c2e-2b62fae9a02c" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/9cb8db37-2cf1-4b05-a41e-4f0e13dc994b" />



## 💬리뷰 요구사항(선택)
- HttpServletRequest 프록시 동작 방식 및 내부 인스턴스 생명 주기를 파악한 후(Request 마다),
- Http Cookie에서 RefreshToken을 추출할 별도의 역할을 맡을 객체가 필요하다 판단하여 RequestContext를 구현했습니다.