### PR TITLE
[Batch] Job 수동 실행 / 중단 / 재시도 API 구현

### DIFF
--- a/client/batch/src/main/java/com/reservation/batch/batchadmin/controller/BatchAdminController.java
+++ b/client/batch/src/main/java/com/reservation/batch/batchadmin/controller/BatchAdminController.java
@@ -1,0 +1,76 @@
+package com.reservation.batch.batchadmin.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reservation.batch.batchadmin.controller.request.TriggerJobRequest;
+import com.reservation.batch.batchadmin.service.BatchAdminService;
+import com.reservation.batch.batchadmin.service.dto.JobExecutionSummary;
+import com.reservation.batch.batchadmin.service.dto.TriggerJobResult;
+import com.reservation.support.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/batch")
+@RequiredArgsConstructor
+public class BatchAdminController {
+
+	private final BatchAdminService batchAdminService;
+
+	@GetMapping("/jobs")
+	@Operation(summary = "모든 Job 이름 확인 API", description = "모든 Job 이름을 확인합니다.")
+	public ApiResponse<List<String>> getAllJobNames() {
+		List<String> jobNames = batchAdminService.getAllJobNames();
+
+		return ApiResponse.ok(jobNames);
+	}
+
+	@GetMapping("/executions")
+	@Operation(summary = "최근 실행된 Job 확인 API", description = "최근 실행된 Job 실행 결과를 확인합니다.")
+	public ApiResponse<List<JobExecutionSummary>> getRecentJobExecutions() {
+		List<JobExecutionSummary> jobExecutionSummaries = batchAdminService.getRecentJobExecutions();
+
+		return ApiResponse.ok(jobExecutionSummaries);
+	}
+
+	@PostMapping("/trigger")
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(summary = "Job 실행 API", description = "특정 Job 실행합니다.")
+	public ApiResponse<TriggerJobResult> triggerJob(@Valid @RequestBody TriggerJobRequest request) {
+		Map<String, String> jobParameters =
+			request.jobParametersOrNull() == null ? Map.of() : request.jobParametersOrNull();
+
+		TriggerJobResult triggerJobResult = batchAdminService.triggerJob(request.jobName(), jobParameters);
+
+		return ApiResponse.ok(triggerJobResult);
+	}
+
+	@PostMapping("/retry/{executionId}")
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(summary = "Job 재실행 API", description = "실패한 JobExecution 재시도합니다.")
+	public ApiResponse<TriggerJobResult> retryJob(@PathVariable long executionId) {
+		TriggerJobResult result = batchAdminService.retryJob(executionId);
+
+		return ApiResponse.ok(result);
+	}
+
+	@PostMapping("/stop/{executionId}")
+	@Operation(summary = "Job 중단 API", description = "진행 중인 JobExecution 중단 요청합니다.")
+	public ApiResponse<Void> stopJob(@PathVariable long executionId) {
+		batchAdminService.stopJob(executionId);
+
+		return ApiResponse.noContent();
+	}
+}

--- a/client/batch/src/main/java/com/reservation/batch/batchadmin/controller/request/TriggerJobRequest.java
+++ b/client/batch/src/main/java/com/reservation/batch/batchadmin/controller/request/TriggerJobRequest.java
@@ -1,0 +1,14 @@
+package com.reservation.batch.batchadmin.controller.request;
+
+import java.util.Map;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+
+public record TriggerJobRequest(
+	@NotNull
+	String jobName,
+	@Nullable
+	Map<String, String> jobParametersOrNull
+) {
+}

--- a/client/batch/src/main/java/com/reservation/batch/batchadmin/service/BatchAdminService.java
+++ b/client/batch/src/main/java/com/reservation/batch/batchadmin/service/BatchAdminService.java
@@ -1,0 +1,135 @@
+package com.reservation.batch.batchadmin.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.NoSuchJobException;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.stereotype.Service;
+
+import com.reservation.batch.batchadmin.service.dto.JobExecutionSummary;
+import com.reservation.batch.batchadmin.service.dto.TriggerJobResult;
+import com.reservation.support.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BatchAdminService {
+	private static final String DEFAULT_RUN_ID = "run.id";
+
+	private final JobRegistry jobRegistry;
+	private final JobExplorer jobExplorer;
+	private final JobRepository jobRepository;
+	private final TaskExecutorJobLauncher taskExecutorJobLauncher;
+
+	public List<String> getAllJobNames() {
+		return jobRegistry.getJobNames()
+			.stream()
+			.toList();
+	}
+
+	public List<JobExecutionSummary> getRecentJobExecutions() {
+		return jobExplorer.findRunningJobExecutions(null)
+			.stream().map(JobExecutionSummary::from).toList();
+	}
+
+	public TriggerJobResult triggerJob(String triggerJobName, Map<String, String> triggerJobParameters) {
+		Job findJob = getJob(triggerJobName);
+
+		// JobParameters 변환
+		JobParametersBuilder builder = new JobParametersBuilder();
+		triggerJobParameters.forEach(builder::addString);
+
+		// run.id는 매번 달라야 JobInstance 중복되지 않음
+		builder.addLong(DEFAULT_RUN_ID, System.currentTimeMillis());
+
+		JobParameters jobParameters = builder.toJobParameters();
+		JobExecution execution;
+		try {
+			execution = taskExecutorJobLauncher.run(findJob, jobParameters);
+		} catch (Exception e) {
+			log.error("Execution Trigger Job Error", e);
+			throw ErrorCode.CONFLICT.exception("Job 실행 실패: " + e.getMessage());
+		}
+
+		return new TriggerJobResult(
+			execution.getId(),
+			triggerJobName,
+			execution.getStatus(),
+			execution.getStartTime(),
+			execution.getJobParameters()
+		);
+	}
+
+	private Job getJob(String jobName) {
+		try {
+			return jobRegistry.getJob(jobName);
+		} catch (NoSuchJobException e) {
+			log.error("Find Trigger Job Error", e);
+			throw ErrorCode.CONFLICT.exception("존재하지 않는 Job 입니다.");
+		}
+	}
+
+	public TriggerJobResult retryJob(long executionId) {
+		JobExecution previousExecution = jobExplorer.getJobExecution(executionId);
+		if (previousExecution == null) {
+			throw ErrorCode.NOT_FOUND.exception("해당 ExecutionId를 찾을 수 없습니다.");
+		}
+		if (!previousExecution.getStatus().isUnsuccessful()) {
+			throw ErrorCode.CONFLICT.exception("실패한 Job만 재시도할 수 있습니다.");
+		}
+
+		JobInstance jobInstance = previousExecution.getJobInstance();
+
+		Job retryJob = getJob(jobInstance.getJobName());
+		JobParameters jobParameters = previousExecution.getJobParameters();
+
+		JobExecution newExecution;
+		try {
+			newExecution = taskExecutorJobLauncher.run(retryJob, jobParameters);
+		} catch (Exception e) {
+			throw ErrorCode.CONFLICT.exception("Job 재시도 실패: " + e.getMessage());
+		}
+
+		return new TriggerJobResult(
+			newExecution.getId(),
+			retryJob.getName(),
+			newExecution.getStatus(),
+			newExecution.getStartTime(),
+			newExecution.getJobParameters()
+		);
+	}
+
+	private JobExecution getJobExecution(long executionId) {
+		JobExecution jobExecution = jobExplorer.getJobExecution(executionId);
+		if (jobExecution == null) {
+			throw ErrorCode.NOT_FOUND.exception("해당 ExecutionId를 찾을 수 없습니다.");
+		}
+		return jobExecution;
+	}
+
+	public void stopJob(long executionId) {
+		JobExecution jobExecution = getJobExecution(executionId);
+
+		if (jobExecution.isRunning()) {
+			jobExecution.setStatus(BatchStatus.STOPPING); // 상태를 STOPPING으로 변경
+			jobExecution.setExitStatus(new ExitStatus("STOPPING_BY_ADMIN"));
+			jobRepository.update(jobExecution);
+		} else {
+			throw ErrorCode.CONFLICT.exception("현재 실행 중인 Job만 중단할 수 있습니다.");
+		}
+	}
+}

--- a/client/batch/src/main/java/com/reservation/batch/batchadmin/service/dto/JobExecutionSummary.java
+++ b/client/batch/src/main/java/com/reservation/batch/batchadmin/service/dto/JobExecutionSummary.java
@@ -1,0 +1,24 @@
+package com.reservation.batch.batchadmin.service.dto;
+
+import java.time.LocalDateTime;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+
+public record JobExecutionSummary(
+	Long executionId,
+	String jobName,
+	BatchStatus status,
+	LocalDateTime startTime,
+	LocalDateTime endTime) {
+
+	public static JobExecutionSummary from(JobExecution jobExecution) {
+		return new JobExecutionSummary(
+			jobExecution.getId(),
+			jobExecution.getJobInstance().getJobName(),
+			jobExecution.getStatus(),
+			jobExecution.getStartTime(),
+			jobExecution.getEndTime()
+		);
+	}
+}

--- a/client/batch/src/main/java/com/reservation/batch/batchadmin/service/dto/TriggerJobResult.java
+++ b/client/batch/src/main/java/com/reservation/batch/batchadmin/service/dto/TriggerJobResult.java
@@ -1,0 +1,15 @@
+package com.reservation.batch.batchadmin.service.dto;
+
+import java.time.LocalDateTime;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobParameters;
+
+public record TriggerJobResult(
+	Long executionId,
+	String jobName,
+	BatchStatus status,
+	LocalDateTime startTime,
+	JobParameters parameters
+) {
+}

--- a/client/batch/src/main/java/com/reservation/batch/config/AsyncJobLauncherConfig.java
+++ b/client/batch/src/main/java/com/reservation/batch/config/AsyncJobLauncherConfig.java
@@ -1,0 +1,29 @@
+package com.reservation.batch.config;
+
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncJobLauncherConfig {
+
+	@Bean
+	public TaskExecutorJobLauncher asyncJobLauncher(JobRepository jobRepository) throws Exception {
+		TaskExecutorJobLauncher jobLauncher = new TaskExecutorJobLauncher();
+		jobLauncher.setJobRepository(jobRepository);
+
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(4);
+		executor.setMaxPoolSize(8);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("batch-async-");
+		executor.initialize();
+
+		jobLauncher.setTaskExecutor(executor);
+
+		return jobLauncher;
+	}
+
+}

--- a/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/OpenRoomAvailabilityJobConfig.java
+++ b/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/OpenRoomAvailabilityJobConfig.java
@@ -24,6 +24,9 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @RequiredArgsConstructor
 public class OpenRoomAvailabilityJobConfig {
+	private static final int CHUNK_TIME_OUT = 60;
+	private static final int CHUNK_SIZE = 100000;
+
 	private final JobRepository jobRepository;
 	private final PlatformTransactionManager transactionManager;
 
@@ -46,7 +49,7 @@ public class OpenRoomAvailabilityJobConfig {
 		String stepName = "openRoomAvailabilityStep";
 
 		TimeAndSizeBasedCompletionPolicy timeAndSizeBasedCompletionPolicy =
-			new TimeAndSizeBasedCompletionPolicy(5, 100000);
+			new TimeAndSizeBasedCompletionPolicy(CHUNK_TIME_OUT, CHUNK_SIZE);
 
 		return new StepBuilder(stepName, jobRepository)
 			.<List<RoomAutoAvailabilityPolicy>, List<RoomAvailability>>

--- a/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/reader/RoomAutoAvailabilityPolicyListItemReader.java
+++ b/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/reader/RoomAutoAvailabilityPolicyListItemReader.java
@@ -2,35 +2,48 @@ package com.reservation.batch.job.openroomavailability.reader;
 
 import java.util.List;
 
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.reservation.batch.repository.RoomAvailabilityRepository;
 import com.reservation.batch.repository.dto.CursorPage;
 import com.reservation.domain.roomautoavailabilitypolicy.RoomAutoAvailabilityPolicy;
+import com.reservation.support.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @StepScope
 @RequiredArgsConstructor
+@Slf4j
 public class RoomAutoAvailabilityPolicyListItemReader implements ItemReader<List<RoomAutoAvailabilityPolicy>> {
+	private static final int READ_SIZE = 1000;
 
 	private final RoomAvailabilityRepository roomAvailabilityRepository;
 
-	private final int chunkSize = 1000;
+	@Value("#{stepExecution.jobExecution}")
+	private JobExecution jobExecution;
+	
 	private Long lastSeenId = null;
 	private boolean finished = false;
 
 	@Override
 	public List<RoomAutoAvailabilityPolicy> read() {
+		if (jobExecution.isStopping()) {
+			log.error("Job execution stopped {}", jobExecution.getExitStatus().getExitDescription());
+			throw ErrorCode.CONFLICT.exception("Job 중단 요청됨 → Reader 중단");
+		}
+
 		if (finished) {
 			return null;
 		}
 
 		CursorPage<RoomAutoAvailabilityPolicy, Long> cursorPage =
-			roomAvailabilityRepository.fetchNextPage(lastSeenId, chunkSize);
+			roomAvailabilityRepository.fetchNextPage(lastSeenId, READ_SIZE);
 
 		if (cursorPage.content().isEmpty()) {
 			finished = true;

--- a/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/writer/RoomAvailabilityBatchWriter.java
+++ b/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/writer/RoomAvailabilityBatchWriter.java
@@ -3,25 +3,38 @@ package com.reservation.batch.job.openroomavailability.writer;
 import java.sql.Date;
 import java.util.List;
 
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import com.reservation.domain.roomavailability.RoomAvailability;
+import com.reservation.support.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @StepScope
 @RequiredArgsConstructor
+@Slf4j
 public class RoomAvailabilityBatchWriter implements ItemWriter<List<RoomAvailability>> {
+	private final static int BULK_INSERT_SIZE = 10000;
 
 	private final JdbcTemplate jdbcTemplate;
+	@Value("#{stepExecution.jobExecution}")
+	private JobExecution jobExecution;
 
 	@Override
 	public void write(Chunk<? extends List<RoomAvailability>> chunk) {
+		if (jobExecution.isStopping()) {
+			log.error("Job execution stopped {}", jobExecution.getExitStatus().getExitDescription());
+			throw ErrorCode.CONFLICT.exception("Job 중단 요청됨 → Writer 중단");
+		}
+
 		List<RoomAvailability> flatList = chunk.getItems().stream()
 			.flatMap(List::stream)
 			.toList();
@@ -33,7 +46,7 @@ public class RoomAvailabilityBatchWriter implements ItemWriter<List<RoomAvailabi
 		jdbcTemplate.batchUpdate(
 			"INSERT INTO room_availability (room_id, date, available_count, price) VALUES (?, ?, ?, ?)",
 			flatList,
-			10000, // Batch Size (한 번에 몇개씩 insert할지)
+			BULK_INSERT_SIZE, // Batch Size (한 번에 몇개씩 insert할지)
 			(ps, roomAvailability) -> {
 				ps.setLong(1, roomAvailability.getRoomId());
 				ps.setDate(2, Date.valueOf(roomAvailability.getDate()));


### PR DESCRIPTION
## 작업 내용 요약

Spring Batch Job에 대한 수동 제어 기능을 위한 Admin API를 구현했습니다.

---

### 구현 API

| Method | URI | 설명 |
|--------|-----|------|
| GET | /batch/jobs | 등록된 Job 목록 조회 |
| GET | /batch/executions | 실행 중인 JobExecution 조회 |
| POST | /batch/trigger | Job 수동 실행 (비동기 처리) |
| POST | /batch/retry/{executionId} | 실패 JobExecution 재실행 |
| POST | /batch/stop/{executionId} | 실행 중 Job 중단 요청 |


<img width="900" alt="image" src="https://github.com/user-attachments/assets/2a02b61d-ad1e-4286-8a79-1b570f4b7a51" />


---

### 주요 구현 포인트

- `TaskExecutorJobLauncher` 도입 → Job 실행을 비동기 처리
- `JobRepository.update(...)` → 중단 상태 강제 반영
- 중단 요청 시 Reader 내부 `Thread.sleep()` 테스트를 통해 스레드 interrupt 발생 확인
- `JobInterruptedException` 자동 발생 + ExitStatus/Message DB 반영 확인
- JobExecution 상태 `STOPPED`, ExitMessage = `JobInterruptedException` 확인

---

### 기타 사항

- Reader 내부 중단 감지를 위해 `jobExecution.isStopping()` 외에 `InterruptedException` 감지도 고려

---

### 리뷰어에게

- Job 중단 시 상태 반영 방식에 대해 고민 포인트가 많았습니다.
- 현 시점에서 실시간 Job 제어는 가능하지만, 추후 운영성 보완 고려 예정입니다.
