### PR TITLE
[Batch] Step 설계를 Chunk-oriented Processing 방식에서 Tasklet 방식 변경

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -16,6 +16,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  batch:
+    job:
+      enabled: false
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
@@ -72,3 +75,15 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+    net.ttddyy.dsproxy.listener: DEBUG
+    com.github.gavlyukovskiy.boot.jdbc.decorator: DEBUG
+
+decorator:
+  datasource:
+    proxy:
+      enabled: true
+      logging: true
+      query:
+        log-level: debug
+        log-slow-query: true
+        slow-query-threshold: 1000

--- a/client/batch/build.gradle
+++ b/client/batch/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+    implementation 'com.github.gavlyukovskiy:datasource-proxy-spring-boot-starter:1.11.0'
 
     runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 

--- a/client/batch/src/main/java/com/reservation/batch/config/JpaConfig.java
+++ b/client/batch/src/main/java/com/reservation/batch/config/JpaConfig.java
@@ -10,5 +10,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EntityScan(basePackages = {"com.reservation.domain", "com.reservation.batch"})
 @EnableJpaRepositories(basePackages = "com.reservation.batch")
 public class JpaConfig {
-
 }

--- a/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/reader/RoomAutoAvailabilityPolicyListItemReader.java
+++ b/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/reader/RoomAutoAvailabilityPolicyListItemReader.java
@@ -1,10 +1,7 @@
 package com.reservation.batch.job.openroomavailability.reader;
 
-import java.util.List;
-
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -20,37 +17,20 @@ import lombok.extern.slf4j.Slf4j;
 @StepScope
 @RequiredArgsConstructor
 @Slf4j
-public class RoomAutoAvailabilityPolicyListItemReader implements ItemReader<List<RoomAutoAvailabilityPolicy>> {
+public class RoomAutoAvailabilityPolicyListItemReader {
 	private static final int READ_SIZE = 1000;
 
 	private final RoomAvailabilityRepository roomAvailabilityRepository;
 
 	@Value("#{stepExecution.jobExecution}")
 	private JobExecution jobExecution;
-	
-	private Long lastSeenId = null;
-	private boolean finished = false;
 
-	@Override
-	public List<RoomAutoAvailabilityPolicy> read() {
+	public CursorPage<RoomAutoAvailabilityPolicy, Long> read(Long lastSeenId) {
 		if (jobExecution.isStopping()) {
 			log.error("Job execution stopped {}", jobExecution.getExitStatus().getExitDescription());
 			throw ErrorCode.CONFLICT.exception("Job 중단 요청됨 → Reader 중단");
 		}
 
-		if (finished) {
-			return null;
-		}
-
-		CursorPage<RoomAutoAvailabilityPolicy, Long> cursorPage =
-			roomAvailabilityRepository.fetchNextPage(lastSeenId, READ_SIZE);
-
-		if (cursorPage.content().isEmpty()) {
-			finished = true;
-			return null;
-		}
-		lastSeenId = cursorPage.nextCursor();
-
-		return cursorPage.content();
+		return roomAvailabilityRepository.fetchNextPage(lastSeenId, READ_SIZE);
 	}
 }

--- a/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/tasklet/OpenRoomAvailabilityTasklet.java
+++ b/client/batch/src/main/java/com/reservation/batch/job/openroomavailability/tasklet/OpenRoomAvailabilityTasklet.java
@@ -1,0 +1,82 @@
+package com.reservation.batch.job.openroomavailability.tasklet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import com.reservation.batch.job.openroomavailability.processor.RoomAutoAvailabilityPolicyListProcessor;
+import com.reservation.batch.job.openroomavailability.reader.RoomAutoAvailabilityPolicyListItemReader;
+import com.reservation.batch.job.openroomavailability.writer.RoomAvailabilityBatchWriter;
+import com.reservation.batch.repository.dto.CursorPage;
+import com.reservation.batch.utils.Perf;
+import com.reservation.domain.roomautoavailabilitypolicy.RoomAutoAvailabilityPolicy;
+import com.reservation.domain.roomavailability.RoomAvailability;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class OpenRoomAvailabilityTasklet implements Tasklet {
+	private static final long TIMEOUT_MILLIS = 5000L;
+	private static final int MAX_WRITE_COUNT = 100000;
+
+	private final RoomAutoAvailabilityPolicyListItemReader roomAutoAvailabilityPolicyListItemReader;
+	private final RoomAutoAvailabilityPolicyListProcessor roomAutoAvailabilityPolicyListProcessor;
+	private final RoomAvailabilityBatchWriter roomAvailabilityBatchWriter;
+
+	@Override
+	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+		long executeStartTime = System.currentTimeMillis();
+		boolean readProcessorWriterSet = false;
+		List<RoomAvailability> writeRoomAvailabilities = new ArrayList<>();
+
+		Long lastSeenId = chunkContext.getAttribute("lastSeenId") != null
+			? (Long)chunkContext.getAttribute("lastSeenId")
+			: null;
+		boolean hasNext = true;
+		Perf perf = new Perf();
+
+		while (!readProcessorWriterSet) {
+			CursorPage<RoomAutoAvailabilityPolicy, Long> roomAutoAvailabilityPolicyLongCursorPage =
+				roomAutoAvailabilityPolicyListItemReader.read(lastSeenId);
+			contribution.incrementReadCount();
+
+			List<RoomAutoAvailabilityPolicy> readRoomAutoAvailabilityPolicies =
+				roomAutoAvailabilityPolicyLongCursorPage.content();
+			lastSeenId = roomAutoAvailabilityPolicyLongCursorPage.nextCursor();
+			hasNext = roomAutoAvailabilityPolicyLongCursorPage.hasNext();
+			perf.log("readerRows", readRoomAutoAvailabilityPolicies.size());
+
+			List<RoomAvailability> roomAvailabilities =
+				roomAutoAvailabilityPolicyListProcessor.process(readRoomAutoAvailabilityPolicies);
+			contribution.incrementFilterCount(1L);
+			perf.log("emittedRows", roomAvailabilities.size());
+
+			writeRoomAvailabilities.addAll(roomAvailabilities);
+
+			if (!hasNext) {
+				break;
+			}
+			readProcessorWriterSet = System.currentTimeMillis() - executeStartTime > TIMEOUT_MILLIS
+				|| writeRoomAvailabilities.size() > MAX_WRITE_COUNT;
+		}
+
+		roomAvailabilityBatchWriter.write(writeRoomAvailabilities);
+		contribution.incrementWriteCount(1L);
+		perf.log("writeRows", writeRoomAvailabilities.size());
+
+		if (hasNext) {
+			chunkContext.setAttribute("lastSeenId", lastSeenId);
+			return RepeatStatus.CONTINUABLE;
+		}
+
+		return RepeatStatus.FINISHED;
+	}
+}

--- a/client/batch/src/main/java/com/reservation/batch/repository/JpaRoomAvailabilityRepository.java
+++ b/client/batch/src/main/java/com/reservation/batch/repository/JpaRoomAvailabilityRepository.java
@@ -11,7 +11,7 @@ import com.reservation.batch.repository.dto.FindAvailabilityInRoomIdsResult;
 import com.reservation.domain.roomavailability.RoomAvailability;
 
 public interface JpaRoomAvailabilityRepository extends JpaRepository<RoomAvailability, Long> {
-	@Query("SELECT ra.roomId, ra.date " +
+	@Query("SELECT new com.reservation.batch.repository.dto.FindAvailabilityInRoomIdsResult(ra.roomId, ra.date)  " +
 		"FROM RoomAvailability ra " +
 		"WHERE ra.roomId IN :roomIds " +
 		"AND ra.date BETWEEN :startDate AND :endDate")

--- a/client/batch/src/main/java/com/reservation/batch/repository/RoomAvailabilityRepository.java
+++ b/client/batch/src/main/java/com/reservation/batch/repository/RoomAvailabilityRepository.java
@@ -22,7 +22,7 @@ public class RoomAvailabilityRepository {
 
 		List<RoomAutoAvailabilityPolicy> results = em.createQuery(
 				"SELECT p FROM RoomAutoAvailabilityPolicy p " +
-					"WHERE p.enabled = true AND p.id > :lastSeenId " +
+					"WHERE p.enabled = true AND p.id >= :lastSeenId " +
 					"ORDER BY p.id ASC", RoomAutoAvailabilityPolicy.class)
 			.setParameter("lastSeenId", lastSeenId)
 			.setMaxResults(pageSize + 1)

--- a/client/batch/src/main/java/com/reservation/batch/repository/dto/FindAvailabilityInRoomIdsResult.java
+++ b/client/batch/src/main/java/com/reservation/batch/repository/dto/FindAvailabilityInRoomIdsResult.java
@@ -6,4 +6,8 @@ public record FindAvailabilityInRoomIdsResult(
 	long roomId,
 	LocalDate date
 ) {
+	public FindAvailabilityInRoomIdsResult(long roomId, LocalDate date) {
+		this.roomId = roomId;
+		this.date = date;
+	}
 }

--- a/client/batch/src/main/java/com/reservation/batch/utils/Perf.java
+++ b/client/batch/src/main/java/com/reservation/batch/utils/Perf.java
@@ -1,0 +1,14 @@
+package com.reservation.batch.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class Perf {
+	private long t = System.currentTimeMillis();
+
+	void log(String msg, long value) {
+		long now = System.currentTimeMillis();
+		log.info("[PERF] {}={} took {} ms", msg, value, now - t);
+		t = now;
+	}
+}

--- a/client/batch/src/main/java/com/reservation/batch/utils/Perf.java
+++ b/client/batch/src/main/java/com/reservation/batch/utils/Perf.java
@@ -3,10 +3,10 @@ package com.reservation.batch.utils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-class Perf {
+public class Perf {
 	private long t = System.currentTimeMillis();
 
-	void log(String msg, long value) {
+	public void log(String msg, long value) {
 		long now = System.currentTimeMillis();
 		log.info("[PERF] {}={} took {} ms", msg, value, now - t);
 		t = now;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #75 

## 💡 Reviewer용 요약

이번 PR은 기존 Chunk-oriented Processing 방식에서  
Tasklet 방식으로 Step 설계를 전환하여  
비선형 Input/Output 구조에 맞는 Output 중심 Writer 설계를 도입한 작업입니다.

## 🔍 리뷰 집중 요청

- Tasklet 반복 로직의 종료 조건 설계 (`RepeatStatus`)
- Output 기준으로 Writer 수행 흐름이 잘 맞는지
- Chunk → Tasklet 전환으로 인한 배치 Job 전체 안정성

---

## 🔍 주요 변경 내용

### 1️⃣ 설계 전환 이유
- Chunk 방식:
    - `chunk size` 기준으로 read() 반복 후 processor(), writer() 실행
    - Input 기준으로 고정되어 있어 Output 양을 제어하기 어려움
- 비즈니스 요구:
    - Read → Processor → Writer의 관계가 비선형
    - Read 수천 번 → Output 0개 가능
    - Read 1번 → Output 수만·수십만 개 가능

---

### 2️⃣ Tasklet 방식 설계
- Step을 Tasklet 기반으로 재구성
- `execute()` 내부에서:
    - [read → processor] 세트 반복 수행
    - Output이 일정량 이상 모이면 Writer 실행
- RepeatStatus를 통해 반복 제어 및 종료 처리

---

### 3️⃣ 기대 효과
- Output 중심 설계로 Writer 성능 최적화
- 비즈니스 요구에 따른 유연한 배치 처리
- 기존 Chunk 방식에서 발생하던 성능·설계 상의 비효율 제거

---

## 💬 비고

- 본 PR은 **설계 전환 작업**까지 포함
- 추가로 진행 예정:
    - 더미 데이터 세팅
    - 성능 측정 및 기록
    - Writer 성능 개선 및 병렬 처리 실험
