### PR TITLE
결제 전 단계의 객실 예약 생성 API 구현

### DIFF
--- a/client/customer/src/main/java/com/reservation/customer/reservation/controller/ReservationController.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/controller/ReservationController.java
@@ -1,0 +1,41 @@
+package com.reservation.customer.reservation.controller;
+
+import static com.reservation.customer.auth.controller.AuthController.*;
+import static com.reservation.support.response.ApiResponse.*;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reservation.auth.annotation.LoginUserId;
+import com.reservation.customer.reservation.controller.request.RoomReservationRequest;
+import com.reservation.customer.reservation.service.ReservationService;
+import com.reservation.customer.reservation.service.dto.CreateReservationResult;
+import com.reservation.support.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/reservations")
+@Tag(name = "객실 예약 API", description = "객실 예약 관리 API 입니다.")
+@PreAuthorize(PRE_AUTH_ROLE_CUSTOMER) //✅일반 고객만 접근 가능
+@RequiredArgsConstructor
+public class ReservationController {
+	private final ReservationService reservationService;
+
+	@PostMapping()
+	@Operation(summary = "객실 예약 생성 API", description = "결제 직전 상태의 임시 예약 정보를 생성합니다.")
+	public ApiResponse<CreateReservationResult> createRoomReservation(
+		@LoginUserId Long memberId,
+		@RequestBody RoomReservationRequest request
+	) {
+		CreateReservationResult result =
+			reservationService.createReservation(memberId, request.validateToCreateCommand());
+		return ok(result);
+	}
+
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/controller/request/RoomReservationRequest.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/controller/request/RoomReservationRequest.java
@@ -1,0 +1,57 @@
+package com.reservation.customer.reservation.controller.request;
+
+import java.time.LocalDate;
+
+import com.reservation.customer.reservation.service.dto.CreateReservationCommand;
+import com.reservation.support.exception.ErrorCode;
+
+public record RoomReservationRequest(
+	Long roomTypeId,
+	LocalDate checkIn,
+	LocalDate checkOut,
+	Integer guestCount,
+	String customerName,
+	String phoneNumber,
+	String paymentMethod,
+	boolean agreeToTerms
+) {
+	public CreateReservationCommand validateToCreateCommand() {
+		if (roomTypeId == null || roomTypeId <= 0) {
+			throw ErrorCode.BAD_REQUEST.exception("roomTypeId는 필수입니다.");
+		}
+		if (checkIn == null || checkOut == null) {
+			throw ErrorCode.BAD_REQUEST.exception("체크인/체크아웃 날짜는 필수입니다.");
+		}
+		if (!checkOut.isAfter(checkIn)) {
+			throw ErrorCode.BAD_REQUEST.exception("체크아웃은 체크인보다 이후여야 합니다.");
+		}
+		if (checkIn.isBefore(LocalDate.now())) {
+			throw ErrorCode.BAD_REQUEST.exception("체크인은 오늘 이후여야 합니다.");
+		}
+		if (guestCount == null || guestCount <= 0) {
+			throw ErrorCode.BAD_REQUEST.exception("투숙 인원은 1명 이상이어야 합니다.");
+		}
+		if (customerName == null || customerName.isBlank()) {
+			throw ErrorCode.BAD_REQUEST.exception("예약자 이름은 필수입니다.");
+		}
+		if (phoneNumber == null || phoneNumber.isBlank()) {
+			throw ErrorCode.BAD_REQUEST.exception("연락처는 필수입니다.");
+		}
+		if (paymentMethod == null || paymentMethod.isBlank()) {
+			throw ErrorCode.BAD_REQUEST.exception("결제 수단은 필수입니다.");
+		}
+		if (!agreeToTerms) {
+			throw ErrorCode.BAD_REQUEST.exception("약관에 동의해야 예약이 가능합니다.");
+		}
+
+		return new CreateReservationCommand(
+			roomTypeId,
+			checkIn,
+			checkOut,
+			guestCount,
+			customerName,
+			phoneNumber,
+			paymentMethod
+		);
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/repository/JpaReservationRepository.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/repository/JpaReservationRepository.java
@@ -1,0 +1,8 @@
+package com.reservation.customer.reservation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.domain.reservation.Reservation;
+
+public interface JpaReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/ReservationService.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/ReservationService.java
@@ -1,0 +1,104 @@
+package com.reservation.customer.reservation.service;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reservation.customer.reservation.repository.JpaReservationRepository;
+import com.reservation.customer.reservation.service.dto.CreateReservationCommand;
+import com.reservation.customer.reservation.service.dto.CreateReservationResult;
+import com.reservation.customer.roomavailability.repository.JpaRoomAvailabilityRepository;
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+import com.reservation.domain.roomavailability.OriginRoomAvailability;
+import com.reservation.support.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+	private final JpaReservationRepository reservationRepository;
+	private final JpaRoomAvailabilityRepository roomAvailabilityRepository;
+
+	@Transactional
+	public CreateReservationResult createReservation(Long memberId, CreateReservationCommand command) {
+		// 1. 예약 가능 여부 확인
+		validateAvailability(command);
+
+		// 2. 수량 차감 (낙관적 락 기반)
+		decreaseAvailabilityCount(command);
+
+		// 3. 총 숙박 요금 계산
+		int totalPrice = calculateTotalPrice(command);
+
+		// 4. 임시 예약(PENDING) 생성
+		Reservation reservation = reservationRepository.save(
+			Reservation.builder()
+				.roomTypeId(command.roomTypeId())
+				.memberId(memberId)
+				.checkIn(command.checkIn())
+				.checkOut(command.checkOut())
+				.guestCount(command.guestCount())
+				.customerName(command.customerName())
+				.phoneNumber(command.phoneNumber())
+				.paymentMethod(command.paymentMethod())
+				.totalPrice(totalPrice)
+				.status(ReservationStatus.PENDING)
+				.build()
+		);
+
+		// 5. 결제 URL 생성 (PG 연동 / Mock)
+		String paymentUrl = generatePaymentUrl(reservation);
+
+		return new CreateReservationResult(
+			reservation.getId(),
+			reservation.getStatus(),
+			reservation.getTotalPrice(),
+			paymentUrl
+		);
+	}
+
+	private void validateAvailability(CreateReservationCommand command) {
+		int requiredDayCount = (int)ChronoUnit.DAYS.between(command.checkIn(), command.checkOut());
+
+		long count = roomAvailabilityRepository.countByRoomTypeIdAndOpenDateBetweenAndAvailableCountGreaterThanEqual(
+			command.roomTypeId(), command.checkIn(), command.checkOut().minusDays(1), 1
+		);
+
+		if (count < requiredDayCount) {
+			throw ErrorCode.CONFLICT.exception("선택한 날짜에는 객실 예약이 불가능합니다.");
+		}
+	}
+
+	private int calculateTotalPrice(CreateReservationCommand command) {
+		return roomAvailabilityRepository.sumPriceByRoomTypeIdAndDateRange(
+			command.roomTypeId(), command.checkIn(), command.checkOut().minusDays(1)
+		);
+	}
+
+	private String generatePaymentUrl(Reservation reservation) {
+		// PG 연동 시 reservationId를 넘겨야 함
+		return "https://mock-pg.com/pay?reservationId=" + reservation.getId();
+	}
+
+	private void decreaseAvailabilityCount(CreateReservationCommand command) {
+		List<OriginRoomAvailability> availabilities =
+			roomAvailabilityRepository.findAllByRoomTypeIdAndOpenDateBetween(
+				command.roomTypeId(), command.checkIn(), command.checkOut().minusDays(1)
+			);
+
+		if (availabilities.size() != ChronoUnit.DAYS.between(command.checkIn(), command.checkOut())) {
+			throw ErrorCode.CONFLICT.exception("예약 가능한 날짜 수량이 부족합니다.");
+		}
+
+		for (OriginRoomAvailability availability : availabilities) {
+			availability.decreaseAvailableCount(); // 내부에서 availableCount-- 및 예외 처리
+		}
+
+		// 버전 기반 낙관적 락으로 saveAll 시점에 충돌 검증
+		roomAvailabilityRepository.saveAll(availabilities);
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationCommand.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationCommand.java
@@ -1,0 +1,14 @@
+package com.reservation.customer.reservation.service.dto;
+
+import java.time.LocalDate;
+
+public record CreateReservationCommand(
+	Long roomTypeId,
+	LocalDate checkIn,
+	LocalDate checkOut,
+	int guestCount,
+	String customerName,
+	String phoneNumber,
+	String paymentMethod
+) {
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationResult.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationResult.java
@@ -1,0 +1,11 @@
+package com.reservation.customer.reservation.service.dto;
+
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+public record CreateReservationResult(
+	Long reservationId,
+	ReservationStatus status,
+	int totalPrice,
+	String paymentUrl
+) {
+}

--- a/client/customer/src/main/java/com/reservation/customer/roomavailability/controller/RoomAvailabilityController.java
+++ b/client/customer/src/main/java/com/reservation/customer/roomavailability/controller/RoomAvailabilityController.java
@@ -47,7 +47,7 @@ public class RoomAvailabilityController {
 		return ok(searchResults);
 	}
 
-	@GetMapping("{accommodationId}/rooms")
+	@GetMapping("/{accommodationId}/rooms")
 	@Operation(summary = "예약 가능한 객실 리스트 조회 API", description = "일반 사용자가 예약 가능한 객실 리스트를 조회합니다.")
 	public ApiResponse<List<AvailableRoomTypeResult>> findAvailableRoomTypes(
 		@PathVariable Long accommodationId,

--- a/client/customer/src/main/java/com/reservation/customer/roomavailability/repository/JpaRoomAvailabilityRepository.java
+++ b/client/customer/src/main/java/com/reservation/customer/roomavailability/repository/JpaRoomAvailabilityRepository.java
@@ -1,0 +1,33 @@
+package com.reservation.customer.roomavailability.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.reservation.domain.roomavailability.OriginRoomAvailability;
+
+public interface JpaRoomAvailabilityRepository extends JpaRepository<OriginRoomAvailability, Long> {
+	long countByRoomTypeIdAndOpenDateBetweenAndAvailableCountGreaterThanEqual(
+		Long roomTypeId, LocalDate startDate, LocalDate endDate, int availableCount
+	);
+
+	@Query("""
+		    SELECT COALESCE(SUM(o.price), 0)
+		    FROM OriginRoomAvailability o
+		    WHERE o.roomTypeId = :roomTypeId
+		    AND o.openDate BETWEEN :startDate AND :endDate
+		""")
+	int sumPriceByRoomTypeIdAndDateRange(
+		@Param("roomTypeId") Long roomTypeId,
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate
+	);
+
+	List<OriginRoomAvailability> findAllByRoomTypeIdAndOpenDateBetween(
+		Long roomTypeId, LocalDate startDate, LocalDate endDate
+	);
+}
+

--- a/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
@@ -1,0 +1,108 @@
+package com.reservation.domain.reservation;
+
+import java.time.LocalDate;
+
+import com.reservation.domain.base.BaseEntity;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+import com.reservation.support.exception.ErrorCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation extends BaseEntity {
+	@Column(nullable = false)
+	private Long roomTypeId;
+
+	@Column(nullable = false)
+	private Long memberId;
+
+	@Column(nullable = false)
+	private LocalDate checkIn;
+
+	@Column(nullable = false)
+	private LocalDate checkOut;
+
+	@Column(nullable = false)
+	private Integer guestCount;
+
+	@Column(nullable = false)
+	private String customerName;
+
+	@Column(nullable = false)
+	private String phoneNumber;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ReservationStatus status;
+
+	@Column(nullable = false)
+	private Integer totalPrice;
+
+	@Column(nullable = false)
+	private String paymentMethod; // 예: "kakao", "toss"
+
+	@Builder
+	public Reservation(
+		Long id,
+		Long roomTypeId,
+		Long memberId,
+		LocalDate checkIn,
+		LocalDate checkOut,
+		Integer guestCount,
+		String customerName,
+		String phoneNumber,
+		Integer totalPrice,
+		String paymentMethod,
+		ReservationStatus status
+	) {
+		if (roomTypeId == null || roomTypeId <= 0)
+			throw ErrorCode.BAD_REQUEST.exception("roomTypeId는 필수입니다.");
+		if (memberId == null || memberId <= 0)
+			throw ErrorCode.BAD_REQUEST.exception("memberId 필수입니다.");
+		if (checkIn == null || checkOut == null || !checkOut.isAfter(checkIn))
+			throw ErrorCode.BAD_REQUEST.exception("체크인/체크아웃 날짜가 유효하지 않습니다.");
+		if (guestCount == null || guestCount <= 0)
+			throw ErrorCode.BAD_REQUEST.exception("투숙 인원은 필수입니다.");
+		if (customerName == null || customerName.isBlank())
+			throw ErrorCode.BAD_REQUEST.exception("예약자 이름은 필수입니다.");
+		if (phoneNumber == null || phoneNumber.isBlank())
+			throw ErrorCode.BAD_REQUEST.exception("연락처는 필수입니다.");
+		if (totalPrice == null || totalPrice <= 0)
+			throw ErrorCode.BAD_REQUEST.exception("총 금액은 필수입니다.");
+		if (paymentMethod == null || paymentMethod.isBlank())
+			throw ErrorCode.BAD_REQUEST.exception("결제 수단은 필수입니다.");
+
+		this.id = id;
+		this.roomTypeId = roomTypeId;
+		this.memberId = memberId;
+		this.checkIn = checkIn;
+		this.checkOut = checkOut;
+		this.guestCount = guestCount;
+		this.customerName = customerName;
+		this.phoneNumber = phoneNumber;
+		this.totalPrice = totalPrice;
+		this.paymentMethod = paymentMethod;
+		this.status = status != null ? status : ReservationStatus.PENDING;
+	}
+
+	public void markConfirmed() {
+		this.status = ReservationStatus.CONFIRMED;
+	}
+
+	public void markCanceled() {
+		this.status = ReservationStatus.CANCELED;
+	}
+
+	public void markExpired() {
+		this.status = ReservationStatus.EXPIRED;
+	}
+}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -1,0 +1,8 @@
+package com.reservation.domain.reservation.enums;
+
+public enum ReservationStatus {
+	PENDING,     // 결제 대기 중
+	CONFIRMED,   // 결제 완료 및 예약 확정
+	CANCELED,    // 사용자 취소 or 결제 실패
+	EXPIRED      // 결제 시간 초과로 자동 무효
+}

--- a/core/domain/src/main/java/com/reservation/domain/roomavailability/OriginRoomAvailability.java
+++ b/core/domain/src/main/java/com/reservation/domain/roomavailability/OriginRoomAvailability.java
@@ -7,6 +7,7 @@ import com.reservation.support.exception.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,10 @@ public class OriginRoomAvailability extends BaseEntity {
 
 	@Column(nullable = false)
 	private Integer availableCount; // 예약 가능 개수
+
+	@Version
+	@Column(nullable = false)
+	private int version;
 
 	@Builder
 	public OriginRoomAvailability(Long id, long roomTypeId, LocalDate openDate, int price, int availableCount) {
@@ -50,5 +55,12 @@ public class OriginRoomAvailability extends BaseEntity {
 		this.openDate = openDate;
 		this.price = price;
 		this.availableCount = availableCount;
+	}
+
+	public void decreaseAvailableCount() {
+		if (this.availableCount <= 0) {
+			throw ErrorCode.CONFLICT.exception("해당 날짜의 객실 수량이 부족합니다.");
+		}
+		this.availableCount -= 1;
 	}
 }


### PR DESCRIPTION
## 연관 이슈
- #86 

## ✅ 주요 구현 내용

* 고객이 선택한 `roomTypeId`, `checkIn ~ checkOut` 날짜, 인원 등을 기반으로
  **예약 가능한 경우에만** 임시 예약 정보를 생성하는 API를 구현.
* 생성된 예약은 `ReservationStatus.PENDING` 상태로 저장되며,
  **PG 결제 요청을 위한 paymentUrl을 함께 응답**.
* 예약 생성 시 **해당 날짜별 건수(available\_count)을 참가**하여
  **중복 예약/오버부킹을 방지**하는 국고를 적용.

---

## 🧹 상세 기능

### 🔐 요청 조건

* 요청 DTO: `RoomReservationRequest`
* 유효성 검증 포함 (날짜 유효성, 인원 ≥ 1, 약관 동의 필요 등)
* 요청 필드:

  * `roomTypeId`, `checkIn`, `checkOut`, `guestCount`, `customerName`, `phoneNumber`, `paymentMethod`, `agreeToTerms`

### ⚙️ 서비스 처리 환경

1. **예약 가능 여부 검증**

   * 해당 건실(room\_type)의 날짜별 `available_count ≥ 1` 확인
2. **수량 선점 (낭관적 람 적용)**

   * `@Version` 필드가 포함된 `OriginRoomAvailability`을 통해 선점
   * 모든 날짜에 대해 수량 참가 후 saveAll 시점에서 충돌 검정
3. **총 금액 계산**

   * 날짜별 `SUM(price)` 기반 총 금액 산술
4. **예약(PENDING) 저장**
5. **결제 요청용 paymentUrl 생성**

   * (현재는 Mock URL 반환)

---

## 파일 / 메서드

* `RoomReservationRequest`

  * `.validateToCreateCommand(memberId)` 메서드로 유효성 검증 + Command 변환 책임 분리
* `CreateReservationCommand` / `CreateReservationResult`

  * 서비스 계층 입력/출력 DTO로 의종 방향 정리
* `RoomAvailabilityService#createReservation(...)`
* `OriginRoomAvailabilityRepository`

  * `findAllByRoomTypeIdAndOpenDateBetween`
  * `sumPriceByRoomTypeIdAndDateRange`
* `ReservationRepository#save`

---

## 🥬 테스트 / 검증

* 날짜 유효성, 인원, 수량 부족 시 예외 응답 검증
* 중복 예약 방지 (`available_count` 선점 충돌) → `OptimisticLockException`과 함께 처리
* 정상 예약 시 결제 URL 포함 응답 확인

---

## 허리 작업

* PG 연동 후 **결제 완료 콜백 처리 API**
