### PR TITLE
결제 및 취소 과정에서 예약 상태를 괸리할 Spring Statemachine 도입

### DIFF
--- a/client/customer/build.gradle
+++ b/client/customer/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
     implementation 'org.redisson:redisson-spring-boot-starter:3.48.0'
-    
+    implementation 'org.springframework.statemachine:spring-statemachine-core:4.0.0'
+
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/ReservationStateMachineService.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/ReservationStateMachineService.java
@@ -1,0 +1,67 @@
+package com.reservation.customer.reservation.statemachine;
+
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.support.DefaultStateMachineContext;
+import org.springframework.stereotype.Service;
+
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class ReservationStateMachineService {
+
+	private final StateMachineFactory<ReservationStatus, ReservationEvents> factory;
+
+	public void sendEvent(Reservation reservation, ReservationEvents event) {
+		StateMachine<ReservationStatus, ReservationEvents> stateMachine =
+			factory.getStateMachine(reservation.getId().toString());
+
+		stateMachine.start();
+
+		stateMachine.getStateMachineAccessor()
+			.doWithAllRegions(access -> {
+				access.resetStateMachine(
+					new DefaultStateMachineContext<>(reservation.getStatus(), null, null, null)
+				);
+			});
+
+		stateMachine.sendEvent(
+			MessageBuilder
+				.withPayload(event)
+				.setHeader("reservation", reservation) // 필요 시 액션에서 접근 가능
+				.build()
+		);
+
+		stateMachine.stop();
+	}
+
+	public void sendEvent(Reservation reservation, Integer iamportAmount, ReservationEvents event) {
+		StateMachine<ReservationStatus, ReservationEvents> stateMachine =
+			factory.getStateMachine(reservation.getId().toString());
+
+		stateMachine.start();
+
+		stateMachine.getStateMachineAccessor()
+			.doWithAllRegions(access -> {
+				access.resetStateMachine(
+					new DefaultStateMachineContext<>(reservation.getStatus(), null, null, null)
+				);
+			});
+
+		stateMachine.sendEvent(
+			MessageBuilder
+				.withPayload(event)
+				.setHeader("reservation", reservation) // 필요 시 액션에서 접근 가능
+				.setHeader("iamportAmount", iamportAmount) // 필요 시 액션에서 접근 가능
+				.build()
+		);
+
+		stateMachine.stop();
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
@@ -1,0 +1,157 @@
+package com.reservation.customer.reservation.statemachine;
+
+import static com.reservation.domain.reservation.enums.ReservationEvents.*;
+import static com.reservation.domain.reservation.enums.ReservationStatus.*;
+import static com.reservation.domain.reservation.enums.ReservationStatus.PG_CANCEL_FAIL;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.config.EnableStateMachineFactory;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+import org.springframework.statemachine.guard.Guard;
+
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableStateMachineFactory
+// @EnableStateMachine
+@RequiredArgsConstructor
+public class StateMachineConfig extends StateMachineConfigurerAdapter<ReservationStatus, ReservationEvents> {
+
+	private final Action<ReservationStatus, ReservationEvents> markPaidErrorAction;
+	private final Guard<ReservationStatus, ReservationEvents> isPaymentAmountValidGuard;
+	private final Action<ReservationStatus, ReservationEvents> markPaidAction;
+	private final Guard<ReservationStatus, ReservationEvents> isPaymentAmountInvalidGuard;
+	private final Action<ReservationStatus, ReservationEvents> markExpiredAction;
+	private final Action<ReservationStatus, ReservationEvents> markConfirmedAction;
+	private final Action<ReservationStatus, ReservationEvents> markPaidErrorCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markPgCancelFailAction;
+	private final Action<ReservationStatus, ReservationEvents> markCustomerCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markAdminCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markHostRejectedAction;
+	private final Action<ReservationStatus, ReservationEvents> markCustomerPaidCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markAdminPaidCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markHostPaidCanceledAction;
+
+	@Override
+	public void configure(StateMachineStateConfigurer<ReservationStatus, ReservationEvents> states) throws Exception {
+		states
+			.withStates()
+			.initial(PENDING) // 초기 상태
+			.state(ReservationStatus.EXPIRED) // 결제 시간 초과 상태
+			.state(ReservationStatus.PAID) // 결제 완료 상태
+			.state(ReservationStatus.PAID_ERROR) // 결제 에러 상태
+			.state(ReservationStatus.CUSTOMER_CANCELED) // 사용자 취소 상태
+			.state(ReservationStatus.HOST_REJECTED) // 호스트 거절 상태
+			.state(ReservationStatus.ADMIN_CANCELED) // 관리자 취소 상태
+			.state(ReservationStatus.CONFIRMED) // 예약 확정 상태
+			.state(ReservationStatus.PAID_ERROR_CANCELED) // 결제 에러로 인한 결제 취소 상태
+			.state(ReservationStatus.CUSTOMER_PAID_CANCELED) // 사용자 취소로 인한 결제 취소 상태
+			.state(ReservationStatus.ADMIN_PAID_CANCELED) // 관리자 취소로 인한 결제 취소 상태
+			.state(ReservationStatus.HOST_PAID_CANCELED) // 호스트 거절로 인한 결제 취소 상태
+			.state(ReservationStatus.PG_VALIDATE_ERROR) // PG 검증 실패 상태
+			.state(ReservationStatus.PG_CANCEL_FAIL); // PG 결제 취소 실패 상태
+	}
+
+	@Override
+	public void configure(
+		StateMachineTransitionConfigurer<ReservationStatus, ReservationEvents> transitions
+	) throws Exception {
+		transitions
+			// PENDING → 결제 성공/실패 분기
+			.withExternal()
+			.source(PENDING).target(PAID) // 펜딩에서 -> 결제 완료로
+			.event(VALIDATE_PAYMENT) // 이벤트: 결제 검증
+			.guard(isPaymentAmountValidGuard) // 가드: 결제 금액이 일치하면
+			.action(markPaidAction) // 액션: 결제 완료로 상태 변경
+
+			.and()
+			.withExternal()
+			.source(PENDING).target(PAID_ERROR) // 펜딩에서 -> 결제 에러로
+			.event(VALIDATE_PAYMENT) // 이벤트: 결제 검증
+			.guard(isPaymentAmountInvalidGuard) // 가드: 결제 금액이 불일치하면
+			.action(markPaidErrorAction) // 액션: 결제 에러로 상태 변경
+
+			.and()
+			.withExternal().source(PENDING).target(PG_VALIDATE_ERROR) // 펜딩에서 -> PG 검증 에러로
+			.event(PAYMENT_VALIDATE_ERROR)
+			.action(markPaidErrorAction)
+			.and()
+			.withExternal().source(PENDING).target(EXPIRED)
+			.event(PAYMENT_EXPIRED)
+			.action(markExpiredAction)
+
+			// PG_VALIDATE_ERROR → 재검증
+			.and()
+			.withExternal().source(PG_VALIDATE_ERROR).target(PAID)
+			.event(PAYMENT_SUCCESS)
+			.guard(isPaymentAmountValidGuard)
+			.action(markPaidAction)
+			.and()
+			.withExternal().source(PG_VALIDATE_ERROR).target(PAID_ERROR)
+			.event(PAYMENT_SUCCESS)
+			.guard(isPaymentAmountInvalidGuard)
+			.action(markPaidErrorAction)
+
+			// PAID → 확정
+			.and()
+			.withExternal().source(PAID).target(CONFIRMED)
+			.event(CHECKIN_PASSED)
+			.action(markConfirmedAction)
+
+			// PAID_ERROR → 결제 취소 or 실패
+			.and()
+			.withExternal().source(PAID_ERROR).target(PAID_ERROR_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markPaidErrorCanceledAction)
+			.and()
+			.withExternal().source(PAID_ERROR).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction)
+
+			// PAID → 취소 요청
+			.and()
+			.withExternal().source(PAID).target(CUSTOMER_CANCELED)
+			.event(CUSTOMER_PAYMENT_CANCEL)
+			.action(markCustomerCanceledAction)
+			.and()
+			.withExternal().source(PAID).target(ADMIN_CANCELED)
+			.event(ADMIN_PAYMENT_CANCEL)
+			.action(markAdminCanceledAction)
+			.and()
+			.withExternal().source(PAID).target(HOST_REJECTED)
+			.event(HOST_PAYMENT_CANCEL)
+			.action(markHostRejectedAction)
+
+			// 취소 → 결제 취소 or 실패
+			.and()
+			.withExternal().source(CUSTOMER_CANCELED).target(CUSTOMER_PAID_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markCustomerPaidCanceledAction)
+			.and()
+			.withExternal().source(CUSTOMER_CANCELED).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction)
+			.and()
+			.withExternal().source(ADMIN_CANCELED).target(ADMIN_PAID_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markAdminPaidCanceledAction)
+			.and()
+			.withExternal().source(ADMIN_CANCELED).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction)
+			.and()
+			.withExternal().source(HOST_REJECTED).target(HOST_PAID_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markHostPaidCanceledAction)
+			.and()
+			.withExternal().source(HOST_REJECTED).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction);
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
@@ -46,14 +46,10 @@ public class StateMachineConfig extends StateMachineConfigurerAdapter<Reservatio
 			.state(ReservationStatus.EXPIRED) // 결제 시간 초과 상태
 			.state(ReservationStatus.PAID) // 결제 완료 상태
 			.state(ReservationStatus.PAID_ERROR) // 결제 에러 상태
-			.state(ReservationStatus.CUSTOMER_CANCELED) // 사용자 취소 상태
-			.state(ReservationStatus.HOST_REJECTED) // 호스트 거절 상태
-			.state(ReservationStatus.ADMIN_CANCELED) // 관리자 취소 상태
+			.state(ReservationStatus.CANCELED) // 예약 취소 상태
 			.state(ReservationStatus.CONFIRMED) // 예약 확정 상태
 			.state(ReservationStatus.PAID_ERROR_CANCELED) // 결제 에러로 인한 결제 취소 상태
-			.state(ReservationStatus.CUSTOMER_PAID_CANCELED) // 사용자 취소로 인한 결제 취소 상태
-			.state(ReservationStatus.ADMIN_PAID_CANCELED) // 관리자 취소로 인한 결제 취소 상태
-			.state(ReservationStatus.HOST_PAID_CANCELED) // 호스트 거절로 인한 결제 취소 상태
+			.state(ReservationStatus.PAID_CANCELED) // 결제 취소 상태
 			.state(ReservationStatus.PG_VALIDATE_ERROR) // PG 검증 실패 상태
 			.state(ReservationStatus.PG_CANCEL_FAIL); // PG 결제 취소 실패 상태
 	}
@@ -116,41 +112,41 @@ public class StateMachineConfig extends StateMachineConfigurerAdapter<Reservatio
 
 			// PAID → 취소 요청
 			.and()
-			.withExternal().source(PAID).target(CUSTOMER_CANCELED)
+			.withExternal().source(PAID).target(CANCELED)
 			.event(CUSTOMER_PAYMENT_CANCEL)
 			.action(markCustomerCanceledAction)
 			.and()
-			.withExternal().source(PAID).target(ADMIN_CANCELED)
+			.withExternal().source(PAID).target(CANCELED)
 			.event(ADMIN_PAYMENT_CANCEL)
 			.action(markAdminCanceledAction)
 			.and()
-			.withExternal().source(PAID).target(HOST_REJECTED)
+			.withExternal().source(PAID).target(CANCELED)
 			.event(HOST_PAYMENT_CANCEL)
 			.action(markHostRejectedAction)
 
 			// 취소 → 결제 취소 or 실패
 			.and()
-			.withExternal().source(CUSTOMER_CANCELED).target(CUSTOMER_PAID_CANCELED)
+			.withExternal().source(CANCELED).target(PAID_CANCELED)
 			.event(PG_PAID_CANCEL)
 			.action(markCustomerPaidCanceledAction)
 			.and()
-			.withExternal().source(CUSTOMER_CANCELED).target(PG_CANCEL_FAIL)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(ReservationEvents.PG_CANCEL_FAIL)
 			.action(markPgCancelFailAction)
 			.and()
-			.withExternal().source(ADMIN_CANCELED).target(ADMIN_PAID_CANCELED)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(PG_PAID_CANCEL)
 			.action(markAdminPaidCanceledAction)
 			.and()
-			.withExternal().source(ADMIN_CANCELED).target(PG_CANCEL_FAIL)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(ReservationEvents.PG_CANCEL_FAIL)
 			.action(markPgCancelFailAction)
 			.and()
-			.withExternal().source(HOST_REJECTED).target(HOST_PAID_CANCELED)
+			.withExternal().source(CANCELED).target(PAID_CANCELED)
 			.event(PG_PAID_CANCEL)
 			.action(markHostPaidCanceledAction)
 			.and()
-			.withExternal().source(HOST_REJECTED).target(PG_CANCEL_FAIL)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(ReservationEvents.PG_CANCEL_FAIL)
 			.action(markPgCancelFailAction);
 	}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
@@ -118,7 +118,7 @@ public class ReservationActionConfig {
 	}
 
 	@Bean
-	public Action<ReservationStatus, ReservationEvents> markCustomerCanceledAction() {
+	public Action<ReservationStatus, ReservationEvents> markCanceledAction() {
 		return context -> {
 			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
 			if (reservation == null) {
@@ -127,8 +127,8 @@ public class ReservationActionConfig {
 			}
 			ReservationStatus from = reservation.getStatus();
 
-			reservation.markCustomerCanceled();
-			log.info("예약 [{}] 상태를 'markCustomerCanceled'로 전환합니다.", reservation.getId());
+			reservation.markCanceled();
+			log.info("예약 [{}] 상태를 'markCanceled'로 전환합니다.", reservation.getId());
 
 			ReservationStatus to = reservation.getStatus();
 
@@ -141,7 +141,7 @@ public class ReservationActionConfig {
 	}
 
 	@Bean
-	public Action<ReservationStatus, ReservationEvents> markAdminCanceledAction() {
+	public Action<ReservationStatus, ReservationEvents> markPaidCanceledAction() {
 		return context -> {
 			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
 			if (reservation == null) {
@@ -150,100 +150,8 @@ public class ReservationActionConfig {
 			}
 			ReservationStatus from = reservation.getStatus();
 
-			reservation.markAdminCanceled();
-			log.info("예약 [{}] 상태를 'markAdminCanceled'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markHostRejectedAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markHostRejected();
-			log.info("예약 [{}] 상태를 'markHostRejected'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markCustomerPaidCanceledAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markCustomerPaidCanceled();
-			log.info("예약 [{}] 상태를 'markCustomerPaidCanceled'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markAdminPaidCanceledAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markAdminPaidCanceled();
-			log.info("예약 [{}] 상태를 'markAdminPaidCanceled'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markHostPaidCanceledAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markHostPaidCanceled();
-			log.info("예약 [{}] 상태를 'markHostPaidCanceled'로 전환합니다.", reservation.getId());
+			reservation.markPaidCanceled();
+			log.info("예약 [{}] 상태를 'markPaidCanceled'로 전환합니다.", reservation.getId());
 
 			ReservationStatus to = reservation.getStatus();
 

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
@@ -1,0 +1,313 @@
+package com.reservation.customer.reservation.statemachine.action;
+
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.reservation.customer.reservationstatushistory.repository.ReservationStatusHistoryRepository;
+import com.reservation.customer.roomavailabilitysummary.repository.JpaRoomAvailabilitySummaryRepository;
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+import com.reservation.domain.reservationstatushistory.ReservationStatusHistory;
+import com.reservation.domain.roomavailabilitysummary.RoomAvailabilitySummary;
+import com.reservation.support.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ReservationActionConfig {
+	private final ReservationStatusHistoryRepository historyRepository;
+	private final JpaRoomAvailabilitySummaryRepository jpaAvailabilitySummaryRepository;
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPaidAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPaid();
+			log.info("예약 [{}] 상태를 'markPaid'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPaidErrorAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPaidError();
+			log.info("예약 [{}] 상태를 'markPaidError'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markExpiredAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markExpired();
+			log.info("예약 [{}] 상태를 'markExpired'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markConfirmedAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markConfirmed();
+			log.info("예약 [{}] 상태를 'markConfirmed'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markCustomerCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markCustomerCanceled();
+			log.info("예약 [{}] 상태를 'markCustomerCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markAdminCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markAdminCanceled();
+			log.info("예약 [{}] 상태를 'markAdminCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markHostRejectedAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markHostRejected();
+			log.info("예약 [{}] 상태를 'markHostRejected'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markCustomerPaidCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markCustomerPaidCanceled();
+			log.info("예약 [{}] 상태를 'markCustomerPaidCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markAdminPaidCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markAdminPaidCanceled();
+			log.info("예약 [{}] 상태를 'markAdminPaidCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markHostPaidCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markHostPaidCanceled();
+			log.info("예약 [{}] 상태를 'markHostPaidCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPaidErrorCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPaidErrorCanceled();
+			log.info("예약 [{}] 상태를 'markPaidErrorCanceled'로 전환합니다.", reservation.getId());
+
+			// ✅ 예약 가능 수량 원복
+			RoomAvailabilitySummary summary = jpaAvailabilitySummaryRepository
+				.findOneByRoomTypeIdAndCheckInDate(reservation.getRoomTypeId(), reservation.getCheckIn())
+				.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약 가능 수량이 없습니다."));
+
+			int days = (int)ChronoUnit.DAYS.between(reservation.getCheckIn(), reservation.getCheckOut());
+			summary.increaseAvailability(days);
+			summary.prePersist();
+			jpaAvailabilitySummaryRepository.save(summary);
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPgCancelFailAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPgCancelFail();
+			log.info("예약 [{}] 상태를 'markPgCancelFail'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/guard/ReservationGuardConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/guard/ReservationGuardConfig.java
@@ -1,0 +1,35 @@
+package com.reservation.customer.reservation.statemachine.guard;
+
+import java.util.Objects;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.guard.Guard;
+
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+@Configuration
+public class ReservationGuardConfig {
+
+	@Bean
+	public Guard<ReservationStatus, ReservationEvents> isPaymentAmountValidGuard() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			Integer iamportPrice = (Integer)context.getMessageHeader("paidAmount");
+
+			return Objects.equals(reservation.getTotalPrice(), iamportPrice);
+		};
+	}
+
+	@Bean
+	public Guard<ReservationStatus, ReservationEvents> isPaymentAmountInvalidGuard() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			Integer iamportPrice = (Integer)context.getMessageHeader("paidAmount");
+            
+			return !Objects.equals(reservation.getTotalPrice(), iamportPrice);
+		};
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservationstatushistory/repository/ReservationStatusHistoryRepository.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservationstatushistory/repository/ReservationStatusHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.reservation.customer.reservationstatushistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.reservation.domain.reservationstatushistory.ReservationStatusHistory;
+
+@Repository
+public interface ReservationStatusHistoryRepository extends JpaRepository<ReservationStatusHistory, Long> {
+}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
@@ -111,46 +111,18 @@ public class Reservation extends BaseEntity {
 		return this.status == ReservationStatus.PENDING;
 	}
 
-	public void markCustomerCanceled() {
+	public void markCanceled() {
 		if (this.status != ReservationStatus.PAID) {
-			throw ErrorCode.BAD_REQUEST.exception("사용자 취소는 결제 완료 상태에서만 가능합니다.");
+			throw ErrorCode.BAD_REQUEST.exception("취소는 결제 완료 상태에서만 가능합니다.");
 		}
-		this.status = ReservationStatus.CUSTOMER_CANCELED;
+		this.status = ReservationStatus.CANCELED;
 	}
 
-	public void markAdminCanceled() {
-		if (this.status != ReservationStatus.PAID) {
-			throw ErrorCode.BAD_REQUEST.exception("관리자 취소는 결제 완료 상태에서만 가능합니다.");
+	public void markPaidCanceled() {
+		if (this.status != ReservationStatus.CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("결제 취소는 취소 상태에서만 가능합니다.");
 		}
-		this.status = ReservationStatus.ADMIN_CANCELED;
-	}
-
-	public void markHostRejected() {
-		if (this.status != ReservationStatus.PAID) {
-			throw ErrorCode.BAD_REQUEST.exception("호스트 거절은 결제 완료 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.HOST_REJECTED;
-	}
-
-	public void markCustomerPaidCanceled() {
-		if (this.status != ReservationStatus.CUSTOMER_CANCELED) {
-			throw ErrorCode.BAD_REQUEST.exception("사용자 결제 취소는 사용자 취소 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.CUSTOMER_PAID_CANCELED;
-	}
-
-	public void markAdminPaidCanceled() {
-		if (this.status != ReservationStatus.ADMIN_CANCELED) {
-			throw ErrorCode.BAD_REQUEST.exception("관리자 결제 취소는 관리자 취소 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.ADMIN_PAID_CANCELED;
-	}
-
-	public void markHostPaidCanceled() {
-		if (this.status != ReservationStatus.HOST_REJECTED) {
-			throw ErrorCode.BAD_REQUEST.exception("호스트 결제 취소는 호스트 거절 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.HOST_PAID_CANCELED;
+		this.status = ReservationStatus.PAID_CANCELED;
 	}
 
 	public void markPaidErrorCanceled() {
@@ -161,9 +133,8 @@ public class Reservation extends BaseEntity {
 	}
 
 	public void markPgCancelFail() {
-		if (this.status != ReservationStatus.PAID_ERROR && this.status != ReservationStatus.CUSTOMER_CANCELED &&
-			this.status != ReservationStatus.ADMIN_CANCELED && this.status != ReservationStatus.HOST_REJECTED) {
-			throw ErrorCode.BAD_REQUEST.exception("PG 결제 취소 실패는 결제 에러, 사용자 취소, 관리자 취소, 호스트 거절 상태에서만 가능합니다.");
+		if (this.status != ReservationStatus.PAID_ERROR && this.status != ReservationStatus.CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("PG 결제 취소 실패는 결제 에러, 또는 취소 상태에서만 가능합니다.");
 		}
 		this.status = ReservationStatus.PG_CANCEL_FAIL;
 	}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
@@ -95,8 +95,12 @@ public class Reservation extends BaseEntity {
 		this.status = ReservationStatus.CONFIRMED;
 	}
 
-	public void markCanceled() {
-		this.status = ReservationStatus.CANCELED;
+	public void markPaid() {
+		this.status = ReservationStatus.PAID;
+	}
+
+	public void markPaidError() {
+		this.status = ReservationStatus.PAID_ERROR;
 	}
 
 	public void markExpired() {
@@ -105,5 +109,62 @@ public class Reservation extends BaseEntity {
 
 	public boolean isPending() {
 		return this.status == ReservationStatus.PENDING;
+	}
+
+	public void markCustomerCanceled() {
+		if (this.status != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("사용자 취소는 결제 완료 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.CUSTOMER_CANCELED;
+	}
+
+	public void markAdminCanceled() {
+		if (this.status != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("관리자 취소는 결제 완료 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.ADMIN_CANCELED;
+	}
+
+	public void markHostRejected() {
+		if (this.status != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("호스트 거절은 결제 완료 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.HOST_REJECTED;
+	}
+
+	public void markCustomerPaidCanceled() {
+		if (this.status != ReservationStatus.CUSTOMER_CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("사용자 결제 취소는 사용자 취소 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.CUSTOMER_PAID_CANCELED;
+	}
+
+	public void markAdminPaidCanceled() {
+		if (this.status != ReservationStatus.ADMIN_CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("관리자 결제 취소는 관리자 취소 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.ADMIN_PAID_CANCELED;
+	}
+
+	public void markHostPaidCanceled() {
+		if (this.status != ReservationStatus.HOST_REJECTED) {
+			throw ErrorCode.BAD_REQUEST.exception("호스트 결제 취소는 호스트 거절 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.HOST_PAID_CANCELED;
+	}
+
+	public void markPaidErrorCanceled() {
+		if (this.status != ReservationStatus.PAID_ERROR) {
+			throw ErrorCode.BAD_REQUEST.exception("결제 에러 취소는 결제 에러 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.PAID_ERROR_CANCELED;
+	}
+
+	public void markPgCancelFail() {
+		if (this.status != ReservationStatus.PAID_ERROR && this.status != ReservationStatus.CUSTOMER_CANCELED &&
+			this.status != ReservationStatus.ADMIN_CANCELED && this.status != ReservationStatus.HOST_REJECTED) {
+			throw ErrorCode.BAD_REQUEST.exception("PG 결제 취소 실패는 결제 에러, 사용자 취소, 관리자 취소, 호스트 거절 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.PG_CANCEL_FAIL;
 	}
 }

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationEvents.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationEvents.java
@@ -1,0 +1,40 @@
+package com.reservation.domain.reservation.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ReservationEvents {
+	// 결제 흐름
+	VALIDATE_PAYMENT("결제 검증 요청", "PG에서 결제 금액을 조회하고 검증을 수행"),
+
+	PAYMENT_SUCCESS("결제 성공", "결제 완료"),
+	PAYMENT_FAILURE("결제 실패", "결제 금액 불일치"),
+	PAYMENT_VALIDATE_ERROR("PG 검증 실패", "PG 통신 실패"),
+	PAYMENT_EXPIRED("결제 만료", "결제 시간 초과"),
+
+	// 체크인 흐름
+	CHECKIN_PASSED("체크인 경과", "체크인 날짜 도래"),
+
+	// 취소 요청
+	CUSTOMER_CANCEL("사용자 취소 요청", "결제 전 사용자 취소"),
+	ADMIN_CANCEL("관리자 취소 요청", "결제 전 관리자 취소"),
+	HOST_REJECT("호스트 거절", "결제 전 호스트 거절"),
+
+	// 결제 취소 요청
+	CUSTOMER_PAYMENT_CANCEL("사용자 결제 취소 요청", "결제 후 사용자 취소"),
+	ADMIN_PAYMENT_CANCEL("관리자 결제 취소 요청", "결제 후 관리자 취소"),
+	HOST_PAYMENT_CANCEL("호스트 결제 취소 요청", "결제 후 호스트 거절"),
+
+	PG_PAID_CANCEL("PG 결제 취소 요청", "PG사 결제 취소 요청"),
+
+	// PG 실패
+	PG_CANCEL_FAIL("PG 취소 실패", "결제 취소 요청 실패");
+
+	private final String name;
+	private final String description;
+
+	ReservationEvents(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
+}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -1,8 +1,33 @@
 package com.reservation.domain.reservation.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum ReservationStatus {
-	PENDING,     // 결제 대기 중
-	CONFIRMED,   // 결제 완료 및 예약 확정
-	CANCELED,    // 사용자 취소 or 결제 실패
-	EXPIRED      // 결제 시간 초과로 자동 무효
+	PENDING("결제 대기", "결제 대기 중"),
+	PAID("결제 완료", "결제 및 검증 완료"),
+	CONFIRMED("확정", "예약 확정"),
+
+	EXPIRED("결제 시간 초과", "결제 시간 초과로 자동 무효"),
+	PAID_ERROR("결제 에러", "미결제 혹은 결제 금액 불일치"),
+
+	CUSTOMER_CANCELED("사용자 취소", "사용자 취소"),
+	ADMIN_CANCELED("관리자 취소", "관리자 취소"),
+	HOST_REJECTED("호스트 거절", "호스트 거절"),
+
+	PAID_ERROR_CANCELED("결제 취소", "결제 에러로 인한 결제 취소"),
+	CUSTOMER_PAID_CANCELED("결제 취소", "사용자 취소로 인한 결제 취소"),
+	ADMIN_PAID_CANCELED("결제 취소", "관리자 취소로 인한 결제 취소"),
+	HOST_PAID_CANCELED("결제 취소", "업체 거절로 인한 결제 취소"),
+
+	PG_VALIDATE_ERROR("PG 검증 실패", "PG사 결제 검증 요청 실패"),
+	PG_CANCEL_FAIL("PG 결제 취소 실패", "PG사 결제 취소 요청 실패");
+
+	private final String name;
+	private final String description;
+
+	ReservationStatus(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
 }

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -11,14 +11,10 @@ public enum ReservationStatus {
 	EXPIRED("결제 시간 초과", "결제 시간 초과로 자동 무효"),
 	PAID_ERROR("결제 에러", "미결제 혹은 결제 금액 불일치"),
 
-	CUSTOMER_CANCELED("사용자 취소", "사용자 취소"),
-	ADMIN_CANCELED("관리자 취소", "관리자 취소"),
-	HOST_REJECTED("호스트 거절", "호스트 거절"),
+	CANCELED("예약 취소", "취소 요청으로 인한 취소 상태"),
 
-	PAID_ERROR_CANCELED("결제 취소", "결제 에러로 인한 결제 취소"),
-	CUSTOMER_PAID_CANCELED("결제 취소", "사용자 취소로 인한 결제 취소"),
-	ADMIN_PAID_CANCELED("결제 취소", "관리자 취소로 인한 결제 취소"),
-	HOST_PAID_CANCELED("결제 취소", "업체 거절로 인한 결제 취소"),
+	PAID_ERROR_CANCELED("결제 취소", "결제 에러로 인한 결제 취소 상태"),
+	PAID_CANCELED("결제 취소", "결제 취소 상태"),
 
 	PG_VALIDATE_ERROR("PG 검증 실패", "PG사 결제 검증 요청 실패"),
 	PG_CANCEL_FAIL("PG 결제 취소 실패", "PG사 결제 취소 요청 실패");

--- a/core/domain/src/main/java/com/reservation/domain/reservationstatushistory/ReservationStatusHistory.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservationstatushistory/ReservationStatusHistory.java
@@ -1,0 +1,40 @@
+package com.reservation.domain.reservationstatushistory;
+
+import java.time.LocalDateTime;
+
+import com.reservation.domain.base.BaseEntity;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+import jakarta.persistence.Entity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ReservationStatusHistory extends BaseEntity {
+	private Long reservationId;
+	private ReservationStatus fromStatus;
+	private ReservationStatus toStatus;
+	private LocalDateTime transitionedAt;
+
+	@Builder
+	public ReservationStatusHistory(
+		long reservationId,
+		ReservationStatus fromStatus,
+		ReservationStatus toStatus
+	) {
+		if (reservationId <= 0) {
+			throw new IllegalArgumentException("reservationId는 필수입니다.");
+		}
+		if (fromStatus == null || toStatus == null) {
+			throw new IllegalArgumentException("fromStatus와 toStatus는 필수입니다.");
+		}
+
+		this.reservationId = reservationId;
+		this.fromStatus = fromStatus;
+		this.toStatus = toStatus;
+		this.transitionedAt = LocalDateTime.now();
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #100 

## 📝작업 내용

1. 결제 프로세스를 고려한 예약 상태 및 이벤트 재설계

2. 예약 상태도 설계

3. Spring Statemachine Config 설계

### 스크린샷 (선택)

- 예약 상태도

<img width="725" alt="image" src="https://github.com/user-attachments/assets/8f5e8f73-e52c-4b7a-b5c2-182aafb255c3" />

## 참고할만한 자료(선택)

- Spring Statemachine 공식 문서: https://spring.io/projects/spring-statemachine
- 우아한 형제들 기술 블로그: https://techblog.woowahan.com/19491/