### PR TITLE
Redis 기반 임시 예약 구조로 변경 및 결제 검증 흐름 개선

### DIFF
--- a/client/customer/src/main/java/com/reservation/customer/payment/controller/PaymentController.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/controller/PaymentController.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.reservation.auth.annotation.LoginUserId;
 import com.reservation.customer.payment.controller.request.PaymentCheckRequest;
 import com.reservation.customer.payment.service.PaymentService;
 import com.reservation.customer.payment.service.dto.IamportPayment;
+import com.reservation.customer.payment.service.dto.PaymentCheckCommand;
 import com.reservation.support.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,9 +30,13 @@ public class PaymentController {
 	@PostMapping()
 	@Operation(summary = "결제 확인 API (결제 취소 시 낙관적 락 활용)", description = "결제가 정상적으로 처리 됐는지 확인합니다.")
 	@CrossOrigin(origins = "http://localhost:63342", allowCredentials = "true")
-	public ApiResponse<IamportPayment> optimisticValidationPayment(@RequestBody @Valid PaymentCheckRequest request) {
-		IamportPayment result =
-			paymentService.optimisticValidationPayment(request.paymentUid(), request.reservationId());
+	public ApiResponse<IamportPayment> optimisticValidationPayment(
+		@RequestBody @Valid PaymentCheckRequest request,
+		@LoginUserId long memberId
+	) {
+		PaymentCheckCommand command = request.validateAndToCommand(memberId);
+
+		IamportPayment result = paymentService.optimisticValidationPayment(command);
 
 		return ok(result);
 	}
@@ -38,9 +44,13 @@ public class PaymentController {
 	@PostMapping("redisson")
 	@Operation(summary = "결제 확인 API (결제 취소 시 레디슨 락 활용)", description = "결제가 정상적으로 처리 됐는지 확인합니다.")
 	@CrossOrigin(origins = "http://localhost:63342", allowCredentials = "true")
-	public ApiResponse<IamportPayment> redissonValidationPayment(@RequestBody @Valid PaymentCheckRequest request) {
-		IamportPayment result =
-			paymentService.redissonValidationPayment(request.paymentUid(), request.reservationId());
+	public ApiResponse<IamportPayment> redissonValidationPayment(
+		@RequestBody @Valid PaymentCheckRequest request,
+		@LoginUserId long memberId
+	) {
+		PaymentCheckCommand command = request.validateAndToCommand(memberId);
+
+		IamportPayment result = paymentService.redissonValidationPayment(command);
 
 		return ok(result);
 	}

--- a/client/customer/src/main/java/com/reservation/customer/payment/controller/request/PaymentCheckRequest.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/controller/request/PaymentCheckRequest.java
@@ -1,13 +1,57 @@
 package com.reservation.customer.payment.controller.request;
 
+import java.time.LocalDate;
+
+import com.reservation.customer.payment.service.dto.PaymentCheckCommand;
+import com.reservation.support.exception.ErrorCode;
+
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 
 public record PaymentCheckRequest(
 	@NotNull @NotEmpty
 	String paymentUid,
-	@NotNull @Positive
-	Long reservationId
+
+	@NotNull
+	Long roomTypeId,
+
+	@NotNull
+	LocalDate checkIn,
+
+	@NotNull
+	LocalDate checkOut,
+
+	@NotNull
+	String phoneNumber,
+
+	@NotNull
+	Integer guestsCount
 ) {
+	public PaymentCheckCommand validateAndToCommand(long memberId) {
+		if (paymentUid == null || paymentUid.isEmpty()) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Payment UID must not be empty");
+		}
+		if (roomTypeId == null || roomTypeId <= 0) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Room Type ID must be a positive number");
+		}
+		if (checkIn == null || checkOut == null || checkIn.isAfter(checkOut)) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Check-in and Check-out dates must be valid");
+		}
+		if (phoneNumber == null || phoneNumber.isEmpty()) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Phone number must not be empty");
+		}
+		if (guestsCount == null || guestsCount <= 0) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Guests count must be a positive number");
+		}
+		
+		return new PaymentCheckCommand(
+			memberId,
+			paymentUid,
+			roomTypeId,
+			checkIn,
+			checkOut,
+			phoneNumber,
+			guestsCount
+		);
+	}
 }

--- a/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
@@ -115,6 +115,7 @@ public class PaymentService {
 
 		// 예약 완료
 		reservationRepository.save(optionalTemp.get().toReservation());
+		// Redis 예약 정보 삭제
 		redisTemplate.delete(key);
 
 		return iamportPayment;
@@ -227,8 +228,7 @@ public class PaymentService {
 					.build();
 
 				// 예약 가능 수량 원복
-				return optimisticCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(),
-					iamportPrice);
+				return redissonCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(), iamportPrice);
 			}
 
 			// 결제 완료
@@ -237,6 +237,7 @@ public class PaymentService {
 
 			// 예약 완료
 			reservationRepository.save(optionalTemp.get().toReservation());
+			// Redis 예약 정보 삭제
 			redisTemplate.delete(key);
 
 			return iamportPayment;

--- a/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
@@ -5,17 +5,22 @@ import static com.reservation.support.utils.retry.OptimisticLockingFailureRetryU
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.reservation.customer.payment.repository.JpaPaymentRepository;
 import com.reservation.customer.payment.service.dto.IamportPayment;
+import com.reservation.customer.payment.service.dto.PaymentCheckCommand;
 import com.reservation.customer.payment.service.iamport.Iamport;
 import com.reservation.customer.reservation.repository.JpaReservationRepository;
+import com.reservation.customer.reservation.service.RedisReservationStore;
+import com.reservation.customer.reservation.service.dto.TemporaryReservation;
 import com.reservation.customer.reservation.statemachine.ReservationStateMachineService;
 import com.reservation.customer.roomavailabilitysummary.repository.JpaRoomAvailabilitySummaryRepository;
 import com.reservation.domain.payment.Payment;
@@ -45,53 +50,63 @@ public class PaymentService {
 	private final JpaPaymentRepository paymentRepository;
 	private final JpaReservationRepository reservationRepository;
 	private final JpaRoomAvailabilitySummaryRepository jpaAvailabilitySummaryRepository;
+	private final RedisReservationStore redisReservationStore;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	private final RedissonClient redisson;
 
 	// 결제 검증 과정에서 낙관적 락을 사용하여 예약 가능 수량을 증가시키는 방식
 	@Transactional
-	public IamportPayment optimisticValidationPayment(String paymentUid, long reservationId) {
+	public IamportPayment optimisticValidationPayment(PaymentCheckCommand command) {
 		IamportPayment iamportPayment;
 
-		iamportPayment = new IamportPayment(iamport.paymentByImpUid(paymentUid));
+		iamportPayment = new IamportPayment(iamport.paymentByImpUid(command.paymentUid()));
 
 		// 결제 완료가 아니면
 		if (!iamportPayment.payment().getStatus().equals("paid")) {
 			throw ErrorCode.CONFLICT.exception("결제 미완료 상태입니다. 다시 결제해주세요");
 		}
 
-		// 예약 조회
-		Reservation reservation = reservationRepository.findById(reservationId)
-			.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약된 내역이 없습니다."));
-
-		// 결제해야할 예약 금액
-		int reservationTotalPrice = reservation.getTotalPrice();
 		// 실 결제 금액
 		int iamportPrice = iamportPayment.payment().getAmount().intValue();
 
+		// 결제 정보 생성
 		Payment payment = Payment.builder()
-			.paymentUid(paymentUid)
+			.paymentUid(command.paymentUid())
 			.price(iamportPrice)
 			.status(PaymentStatus.INITIATED)
 			.build();
 
-		// 만약 10분 초과로 이미 예약이 취소된 경우
-		if (reservation.getStatus().equals(ReservationStatus.EXPIRED)) {
-			// 이미 취소된 예약 -> 결제금액 취소(아임포트)
-			payment.markCancelled();
-			paymentRepository.save(payment);
-			return optimisticCancelPayment(reservation, iamportPayment.payment().getImpUid(), iamportPrice);
-		}
+		// Redis 조회
+		String key = String.format(
+			"reservation:%d:%d:%s:%s", command.memberId(), command.roomTypeId(), command.checkIn(), command.checkOut());
 
-		Integer iamportAmount = iamportPayment.payment().getAmount().intValue();
-		stateMachineService.sendEvent(reservation, iamportAmount, ReservationEvents.PAYMENT_FAILURE);
+		Optional<TemporaryReservation> optionalTemp = redisReservationStore.find(key);
 
-		// 만약 10분 초과로 이미 예약이 취소된 경우 또는 결제 금액이 맞지 않는 경우
-		if (iamportPrice != reservationTotalPrice) {
+		// Redis TTL 초과 => 유효하지 않은 예약 OR 결제 금액이 맞지 않는 경우
+		if (optionalTemp.isEmpty() || iamportPrice != optionalTemp.get().totalPrice()) {
 			// 결제금액 위변조로 의심 -> 결제금액 취소(아임포트) 및 예약 취소 & 예약 수량 원복
+			CancelData cancelData = new CancelData(command.paymentUid(), true, null); // 전체 금액 환불
+			iamport.cancelPaymentByImpUid(cancelData);
+
+			// 결제 취소 상태 저장
 			payment.markCancelled();
 			paymentRepository.save(payment);
-			return optimisticCancelPayment(reservation, iamportPayment.payment().getImpUid(), iamportPrice);
+
+			// 예약 오류 정보 생성
+			Reservation paidErrorReservation = Reservation.builder()
+				.roomTypeId(command.roomTypeId())
+				.memberId(command.memberId())
+				.checkOut(command.checkOut())
+				.checkIn(command.checkIn())
+				.status(ReservationStatus.PAID_ERROR)
+				.phoneNumber(command.phoneNumber())
+				.guestCount(command.guestsCount())
+				.totalPrice(iamportPrice)
+				.build();
+
+			// 예약 가능 수량 원복
+			return optimisticCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(), iamportPrice);
 		}
 
 		// 결제 완료
@@ -99,8 +114,9 @@ public class PaymentService {
 		paymentRepository.save(payment);
 
 		// 예약 완료
-		reservation.markPaid();
-		reservationRepository.save(reservation);
+		reservationRepository.save(optionalTemp.get().toReservation());
+		redisTemplate.delete(key);
+
 		return iamportPayment;
 	}
 
@@ -139,25 +155,33 @@ public class PaymentService {
 
 	// 결제 검증 과정에서 레디슨 락을 사용하여 예약 가능 수량을 증가시키는 방식
 	@Transactional
-	public IamportPayment redissonValidationPayment(String paymentUid, long reservationId) {
+	public IamportPayment redissonValidationPayment(PaymentCheckCommand command) {
 		IamportPayment iamportPayment;
 
-		iamportPayment = new IamportPayment(iamport.paymentByImpUid(paymentUid));
+		iamportPayment = new IamportPayment(iamport.paymentByImpUid(command.paymentUid()));
 
 		// 결제 완료가 아니면
 		if (!iamportPayment.payment().getStatus().equals("paid")) {
 			throw ErrorCode.CONFLICT.exception("결제 미완료 상태입니다. 다시 결제해주세요");
 		}
 
-		// 혹시 모를 데드락을 줄이기 위해, 멀티락 X -> 순서대로 락을 획득하는 방식으로 변경
-		// 비관적 락 처리 시작
-		Reservation reservation = reservationRepository.findById(reservationId)
-			.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약된 내역이 없습니다."));
-		RLock reservationLock = redisson.getLock("reservation:lock:" + reservationId);
+		// Redis 조회
+		String key = String.format(
+			"reservation:%d:%d:%s:%s", command.memberId(), command.roomTypeId(), command.checkIn(), command.checkOut());
+		Optional<TemporaryReservation> optionalTemp = redisReservationStore.find(key);
+
+		// 비관적 락 처리 시작 (혹시 모를 데드락을 줄이기 위해, 멀티락 X -> 순서대로 락을 획득하는 방식으로 변경)
+		String reservationLockKey = String.format(
+			"reservation:lock:%d:%d:%s:%s",
+			command.memberId(),
+			command.roomTypeId(),
+			command.checkIn(),
+			command.checkOut());
+		RLock reservationLock = redisson.getLock(reservationLockKey);
 		boolean isReservationLocked = false;
 
-		long roomTypeId = reservation.getRoomTypeId();
-		RLock checkInLock = redisson.getLock("reservation:lock:" + roomTypeId + ":" + reservation.getCheckIn());
+		long roomTypeId = command.roomTypeId();
+		RLock checkInLock = redisson.getLock("reservation:lock:" + roomTypeId + ":" + command.checkIn());
 		boolean isCheckInLock = false;
 
 		try {
@@ -171,32 +195,40 @@ public class PaymentService {
 				throw ErrorCode.CONFLICT.exception("해당 예약 건의 체크인 월은 현재 다른 결제 처리 중입니다. 잠시 후 다시 시도해 주세요.");
 			}
 
-			// 결제해야할 예약 금액
-			int reservationTotalPrice = reservation.getTotalPrice();
 			// 실 결제 금액
 			int iamportPrice = iamportPayment.payment().getAmount().intValue();
 
 			Payment payment = Payment.builder()
-				.paymentUid(paymentUid)
+				.paymentUid(command.paymentUid())
 				.price(iamportPrice)
 				.status(PaymentStatus.INITIATED)
 				.build();
 
-			// 10분 초과로 이미 예약이 취소된 경우
-			if (reservation.getStatus().equals(ReservationStatus.EXPIRED)) {
-				// 이미 취소된 예약 -> 결제금액 취소(아임포트)
-				payment.markCancelled();
-				paymentRepository.save(payment);
-				CancelData cancelData = new CancelData(paymentUid, true, new BigDecimal(iamportPrice));
-				return new IamportPayment(iamport.cancelPaymentByImpUid(cancelData));
-			}
-
-			// 결제 금액이 맞지 않는 경우
-			if (iamportPrice != reservationTotalPrice) {
+			// Redis TTL 초과 => 유효하지 않은 예약 OR 결제 금액이 맞지 않는 경우
+			if (optionalTemp.isEmpty() || iamportPrice != optionalTemp.get().totalPrice()) {
 				// 결제금액 위변조로 의심 -> 결제금액 취소(아임포트) 및 예약 취소 & 예약 수량 원복
+				CancelData cancelData = new CancelData(command.paymentUid(), true, null); // 전체 금액 환불
+				iamport.cancelPaymentByImpUid(cancelData);
+
+				// 결제 취소 상태 저장
 				payment.markCancelled();
 				paymentRepository.save(payment);
-				return redissonCancelPayment(reservation, iamportPayment.payment().getImpUid(), iamportPrice);
+
+				// 예약 오류 정보 생성
+				Reservation paidErrorReservation = Reservation.builder()
+					.roomTypeId(command.roomTypeId())
+					.memberId(command.memberId())
+					.checkOut(command.checkOut())
+					.checkIn(command.checkIn())
+					.status(ReservationStatus.PAID_ERROR)
+					.phoneNumber(command.phoneNumber())
+					.guestCount(command.guestsCount())
+					.totalPrice(iamportPrice)
+					.build();
+
+				// 예약 가능 수량 원복
+				return optimisticCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(),
+					iamportPrice);
 			}
 
 			// 결제 완료
@@ -204,8 +236,9 @@ public class PaymentService {
 			paymentRepository.save(payment);
 
 			// 예약 완료
-			reservation.markPaid();
-			reservationRepository.save(reservation);
+			reservationRepository.save(optionalTemp.get().toReservation());
+			redisTemplate.delete(key);
+
 			return iamportPayment;
 		} catch (Exception e) {
 			log.error(e.getMessage());

--- a/client/customer/src/main/java/com/reservation/customer/payment/service/dto/PaymentCheckCommand.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/service/dto/PaymentCheckCommand.java
@@ -1,0 +1,14 @@
+package com.reservation.customer.payment.service.dto;
+
+import java.time.LocalDate;
+
+public record PaymentCheckCommand(
+	long memberId,
+	String paymentUid,
+	long roomTypeId,
+	LocalDate checkIn,
+	LocalDate checkOut,
+	String phoneNumber,
+	int guestsCount
+) {
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/RedisReservationStore.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/RedisReservationStore.java
@@ -1,0 +1,42 @@
+package com.reservation.customer.reservation.service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.customer.reservation.service.dto.TemporaryReservation;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class RedisReservationStore {
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void save(TemporaryReservation reservation, Duration ttl) {
+		try {
+			String key = reservation.redisKey();
+			String value = objectMapper.writeValueAsString(reservation);
+			redisTemplate.opsForValue().set(key, value, ttl);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Redis 저장 중 JSON 직렬화 실패", e);
+		}
+	}
+
+	public Optional<TemporaryReservation> find(String key) {
+		String json = redisTemplate.opsForValue().get(key);
+		if (json == null)
+			return Optional.empty();
+
+		try {
+			return Optional.of(objectMapper.readValue(json, TemporaryReservation.class));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Redis 조회 중 JSON 역직렬화 실패", e);
+		}
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationResult.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationResult.java
@@ -1,13 +1,9 @@
 package com.reservation.customer.reservation.service.dto;
 
-import com.reservation.domain.reservation.enums.ReservationStatus;
-
 public record CreateReservationResult(
-	Long reservationId,
 	String memberEmail,
 	String memberPhoneNumber,
 	String roomTypeName,
-	ReservationStatus status,
 	int totalPrice,
 	String impUid
 ) {

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/TemporaryReservation.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/TemporaryReservation.java
@@ -1,0 +1,35 @@
+package com.reservation.customer.reservation.service.dto;
+
+import java.time.LocalDate;
+
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+public record TemporaryReservation(
+	Long memberId,
+	Long roomTypeId,
+	LocalDate checkIn,
+	LocalDate checkOut,
+	int guestCount,
+	String phoneNumber,
+	int totalPrice
+) {
+	public String redisKey() {
+		return String.format("reservation:%d:%d:%s:%s",
+			memberId, roomTypeId, checkIn, checkOut
+		);
+	}
+
+	public Reservation toReservation() {
+		return Reservation.builder()
+			.roomTypeId(roomTypeId)
+			.memberId(memberId)
+			.checkIn(checkIn)
+			.checkOut(checkOut)
+			.guestCount(guestCount)
+			.phoneNumber(phoneNumber)
+			.totalPrice(totalPrice)
+			.status(ReservationStatus.PAID) // 결제 검증 성공
+			.build();
+	}
+}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -4,11 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum ReservationStatus {
-	PENDING("결제 대기", "결제 대기 중"),
 	PAID("결제 완료", "결제 및 검증 완료"),
 	CONFIRMED("확정", "예약 확정"),
 
-	EXPIRED("결제 시간 초과", "결제 시간 초과로 자동 무효"),
 	PAID_ERROR("결제 에러", "미결제 혹은 결제 금액 불일치"),
 
 	CANCELED("예약 취소", "취소 요청으로 인한 취소 상태"),


### PR DESCRIPTION
## #️⃣연관된 이슈

- #102 

## 📝작업 내용

- Redis 기반 임시 예약 구조 도입 (TemporaryReservation, RedisReservationStore)
- ReservationService에서 DB 저장 제거 및 TTL 기반 저장으로 전환
- PaymentCheckRequest → PaymentCheckCommand 계층 분리 및 Redis key 구성 정보 포함

- PaymentService:    
   - Redis에서 예약 데이터 조회.   
   - 결제 검증 성공 → Reservation 생성 (PAID).   
   - 검증 실패 or TTL 초과 → 즉시 결제 취소 (Iamport.cancelPaymentByImpUid).    
   - 결제 취소 시 예약 수량 증가 처리 포함

- 상태머신은 Reservation 생성 이후에만 진입하도록 보호

### 🔍 검증 방법

- Redis 저장 여부 확인

- TTL 초과 후 결제 → 자동 환불 처리 확인

- 결제 금액 위변조 시 → 자동 환불 및 Reservation 생성 ❌ 확인

- 정상 결제 시 Reservation 생성 + 상태머신 진입 여부 확인

### 스크린샷 (선택)

#### ✅  PENDING 상태, EXPIRED 상태가 제거됨

- 기존 상태도
 
<img width="665" alt="image" src="https://github.com/user-attachments/assets/a716b47b-76ab-4b5c-a157-94f6b0a188da" />


- 변경된 상태도

<img width="678" alt="image" src="https://github.com/user-attachments/assets/a3db759b-8e72-4637-8e00-5ed94b13f93f" />


## 💬리뷰 요구사항(선택)
