### PR TITLE
 고객 예약 취소 API 구현 (결제 취소 + 수량 복구 포함)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > Java/Spring 기반의 숙소 예약 플랫폼 백엔드 프로젝트입니다.  
 > 고객, 업체(호스트), 관리자 세 가지 사용자 유형에 맞춘 멀티 모듈 아키텍처를 설계하고,  
-**도메인 중심 설계와 인증/인가 기능, 커서 기반 페이징 등** 실전 감각을 기르기 위한 사이드 프로젝트입니다.
+**도메인 중심 설계와 인증/인가 기능, 대용량 Batch 설계, PG 연동을 통한 결제 프로세스 구현 등 등** 실전 감각을 기르기 위한 사이드 프로젝트입니다.
 
 <br>
 
 ## 🛠️ 기술 스택
 
 - Java 21
-- Spring Boot, Spring Security
+- Spring Boot, Spring Batch, Spring Security
 - JPA, MySQL
 - Redis, JWT
 - Gradle (멀티 모듈)
@@ -17,6 +17,61 @@
 - QueryDSL
 
 ---
+
+## 🔗주요 아티클
+
+### Batch 설계 관련
+
+- [매일 수백만 건의 예약 가능 객실, 어떻게 만들까? - 객실 가용성 배치 도입기](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-1-%EB%A7%A4%EC%9D%BC-%EC%88%98%EB%B0%B1%EB%A7%8C-%EA%B1%B4%EC%9D%98-%EC%98%88%EC%95%BD-%EA%B0%80%EB%8A%A5-%EA%B0%9D%EC%8B%A4-%EC%96%B4%EB%96%BB%EA%B2%8C-%EB%A7%8C%EB%93%A4%EA%B9%8C-%EA%B0%9D%EC%8B%A4-%EA%B0%80%EC%9A%A9%EC%84%B1-%EB%B0%B0%EC%B9%98-%EB%8F%84%EC%9E%85%EA%B8%B0)
+- [Chunk vs Tasklet, 상황에 맞는 최적의 도구는?](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-2-Chunk-%EB%B0%A9%EC%8B%9D-%EC%95%84%EB%8B%88-Tasklet%EC%9C%BC%EB%A1%9C-%EA%B0%84%EB%8B%A4)
+- [성능 측정과 병목점 찾기: Tasklet의 한계, 그리고 Processor 최적화](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-3-%EC%84%B1%EB%8A%A5-%EC%B8%A1%EC%A0%95%EA%B3%BC-%EB%B3%91%EB%AA%A9%EC%A0%90-%EC%B0%BE%EA%B8%B0-Tasklet%EC%9D%98-%ED%95%9C%EA%B3%84-%EA%B7%B8%EB%A6%AC%EA%B3%A0-Processor-%EC%B5%9C%EC%A0%81%ED%99%94)
+- [Insert 성능 최적화: PreparedStatement, 그리고 클러스터드 인덱스의 함정](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-4-DB-Insert-%EC%84%B1%EB%8A%A5-%EA%B0%9C%EC%84%A0-PreparedStatement-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98%EA%B3%BC-Lock-%EC%9E%91%EC%84%B1-%EC%A4%91)
+- [클러스터드 인덱스를 넘어서: PK 실험과 LOAD DATA INFILE의 만남](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-5-PK-%EC%9E%AC%EC%84%A4%EA%B3%84-%ED%81%B4%EB%9F%AC%EC%8A%A4%ED%84%B0%EB%93%9C-%EC%9D%B8%EB%8D%B1%EC%8A%A4%EC%99%80%EC%9D%98-%EB%8F%99%ED%96%89)
+- [MySQL 옵션 튜닝의 실패, 구조를 향한 시작](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-6-MySQL-%EC%98%B5%EC%85%98-%ED%8A%9C%EB%8B%9D%EC%9D%98-%EC%8B%A4%ED%8C%A8-%EA%B5%AC%EC%A1%B0%EB%A5%BC-%ED%96%A5%ED%95%9C-%EC%8B%9C%EC%9E%91)
+- [MySQL 튜닝 재도전: 구조적 이해로 옵션을 바라보기](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-7-MySQL-%ED%8A%9C%EB%8B%9D-%EC%9E%AC%EB%8F%84%EC%A0%84-%EA%B5%AC%EC%A1%B0%EC%A0%81-%EC%9D%B4%ED%95%B4%EB%A1%9C-OLAPOLTP-%EA%B7%A0%ED%98%95-%EC%B0%BE%EA%B8%B0)
+- [연박 정책 기반 집계 구조: 성능 병목을 해결하기 위한 데이터 리모델링](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-8-%EC%97%B0%EB%B0%95-%EC%A0%95%EC%B1%85-%EA%B8%B0%EB%B0%98-%EC%A7%91%EA%B3%84-%EA%B5%AC%EC%A1%B0-%EC%84%B1%EB%8A%A5-%EB%B3%91%EB%AA%A9%EC%9D%84-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0-%EC%9C%84%ED%95%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%A6%AC%EB%AA%A8%EB%8D%B8%EB%A7%81)
+
+### JPA/QueryDSL 유틸 설계 관련
+
+- [QueryDSL과 타입 안정성을 고려한 커서 설계기](https://pablo7.tistory.com/entry/%EC%82%AC%EC%9D%B4%EB%93%9C-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-QueryDSL%EA%B3%BC-%ED%83%80%EC%9E%85-%EC%95%88%EC%A0%95%EC%84%B1%EC%9D%84-%EA%B3%A0%EB%A0%A4%ED%95%9C-%EC%BB%A4%EC%84%9C-%EC%84%A4%EA%B3%84%EA%B8%B0)
+- [JPA Pagable 변환 유틸 설계기](https://pablo7.tistory.com/entry/%EC%82%AC%EC%9D%B4%EB%93%9C-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%A0%95%EB%A0%AC-%ED%95%98%EB%82%98%EC%97%90%EB%8F%84-%EC%84%A4%EA%B3%84%EA%B0%80-%EB%93%A4%EC%96%B4%EA%B0%84%EB%8B%A4)
+
+### 기술에 대한 고찰
+
+- [객체 생성에 관한 고찰](https://pablo7.tistory.com/entry/%EA%B0%9D%EC%B2%B4-%EC%83%9D%EC%84%B1%EC%97%90-%EA%B4%80%ED%95%B4)
+- [필요한 기능만 의존하게 하자 (Feat: ISP)](https://pablo7.tistory.com/entry/%EA%B3%A0%EC%B0%B0%ED%95%98%EA%B8%B0-%ED%95%84%EC%9A%94%ED%95%9C-%EA%B8%B0%EB%8A%A5%EB%A7%8C-%EC%9D%98%EC%A1%B4%ED%95%98%EA%B2%8C-%ED%95%98%EC%9E%90)
+- [Lock 전략을 결정하는 건 기술이 아니라 도메인이다](https://pablo7.tistory.com/entry/%EA%B3%A0%EC%B0%B0%ED%95%98%EA%B8%B0-Lock-%EC%A0%84%EB%9E%B5%EC%9D%84-%EA%B2%B0%EC%A0%95%ED%95%98%EB%8A%94-%EA%B1%B4-%EA%B8%B0%EC%88%A0%EC%9D%B4-%EC%95%84%EB%8B%88%EB%9D%BC-%EB%8F%84%EB%A9%94%EC%9D%B8%EC%9D%B4%EB%8B%A4)
+- [Redis는 TTL 때문에 쓰면 과한가?](https://pablo7.tistory.com/entry/%EC%82%AC%EC%9D%B4%EB%93%9C-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-Redis%EB%8A%94-TTL-%EB%95%8C%EB%AC%B8%EC%97%90-%EC%93%B0%EB%A9%B4-%EA%B3%BC%ED%95%9C%EA%B0%80)
+
+## ✅ 구현 기능 요약
+
+### 📌 아키텍처/인프라
+
+- 멀티 모듈 설계 (core, client, batch, file-upload 등)
+- [모듈 간 의존 역전 원칙 (core ↔ client 단방향)](https://github.com/f-lab-edu/hotel-reservation-platform/pull/69)
+- [Docker 기반 개발/운영 환경 구성](https://github.com/f-lab-edu/hotel-reservation-platform/pull/35)
+
+### 🔐 인증/인가
+
+- [JWT 기반 인증](https://github.com/f-lab-edu/hotel-reservation-platform/pull/43)
+- [Spring Security + 필터 체인 커스터마이징](https://github.com/f-lab-edu/hotel-reservation-platform/pull/64)
+- [OAuth 기반 소셜 로그인 연동 구현 (Retry 및 CircuitBreaker 적용 )](https://github.com/f-lab-edu/hotel-reservation-platform/pull/66)
+
+### 💳 예약 + 결제 흐름
+
+- [예약 가계약 생성 구조 도입](https://github.com/f-lab-edu/hotel-reservation-platform/pull/87)
+- [PG 연동을 통한 결제 프로세스 구현](https://github.com/f-lab-edu/hotel-reservation-platform/pull/89)
+
+### ⚙️ Batch 처리
+
+- [대용량 예약 가능 수량 적재 (Tasklet 기반)](https://github.com/f-lab-edu/hotel-reservation-platform/pull/76)
+- [DB 성능 테스트 및 LOAD DATA INFILE 활용 Batch 구조 설계](https://github.com/f-lab-edu/hotel-reservation-platform/pull/81)
+- [성능 튜닝: Redo Log, Buffer Pool, Checkpoint 최적화 실험](https://pablo7.tistory.com/entry/Batch-%EC%8B%9C%EB%A6%AC%EC%A6%88-7-MySQL-%ED%8A%9C%EB%8B%9D-%EC%9E%AC%EB%8F%84%EC%A0%84-%EA%B5%AC%EC%A1%B0%EC%A0%81-%EC%9D%B4%ED%95%B4%EB%A1%9C-OLAPOLTP-%EA%B7%A0%ED%98%95-%EC%B0%BE%EA%B8%B0)
+
+### 🧠 트러블슈팅/실험 기반 개선
+
+- [쿼리 성능 병목 추적(Batch 선집계 반영)](https://github.com/f-lab-edu/hotel-reservation-platform/pull/97)
+- [동시성 고려 (Lock 전략, Redis RLock 등)](https://github.com/f-lab-edu/hotel-reservation-platform/pull/93)
 
 ## 🗺️ 모듈 설계
 
@@ -86,61 +141,3 @@
 1. Entity → core-domain
 2. 필요한 비즈니스 쿼리 → 해당 client- 모듈에서 Repository 구현
 3. 공통 상수·Enum이 필요하면 core-support 에서 관리
-
-<br>
-
-#### 🔐 보안 설정 확장
-
-- 새로운 skipUrls 가 필요하면 JwtProperties.skipUrls(yaml) → SecurityConfig 자동 반영
-- 외부 API 호출 시 CircuitBreaker + Retry 디자인은 core-auth → 공통 유틸 제공 예정
-
-## 💡 주요 기능 및 설계
-
-### ✅ 1. 약관 도메인 설계 및 커서 기반 페이징
-
-- 고객 대상 약관 동의 기능 구현
-- 정렬 필드를 Enum + Generic 구조로 추상화하여 QueryDSL 기반 Keyset 페이징 지원
-
-### ✅ 2. 회원가입 및 인증 / 인가
-
-- 인증번호 발송 및 검증 (Redis TTL 기반)
-- JWT Access/Refresh Token 발급 및 보안 처리
-- `@LoginMember` ArgumentResolver 직접 구현하여 유저 컨텍스트 주입 처리
-
-### ✅ 3. Security 커스터마이징
-
-- JwtFilter 등록 및 인가 처리 로직 명확화
-- CustomAuthenticationEntryPoint 구현 및 AuthErrorType 설계
-- 권한 기반 접근 제어 적용
-
-### ✅ 4. 업체 숙박 정보 관리 - 숙소 등록 / 객실 정보 관리
-
-- 숙소 등록 및 객실 정보 관리 기능 구현
-- 숙소 이미지 업로드 -> 파일 업로드 모듈 분리
-- 예약 가능한 기간 설정 및 예약 가능 여부 체크
-
-<br />
-
-## 🔗블로그
-
-- [Blog Link](https://pablo7.tistory.com/)
-
----
-
-## 📌 진행 상황
-
-- ✅ 핵심 인증/인가 기능 구현 완료
-- ✅ 약관 관리 기능 + Keyset 페이징 구현 완료
-- ✅ 업체 숙소 등록 / 객실 관리 기능 구현 완료
-- ⏳ 숙박 가용 정보 자동화 Batch 구현 진행 중
-- ⏳ 일반 고객 숙소 검색 및 예약 구현 예정
-- 🔄 커밋 이력 및 설계 과정은 GitHub + 블로그로 지속 기록 중입니다
-
----
-
-## 🙋‍♂️ 프로젝트 목표
-
-- 도메인 중심 아키텍처와 구조적 책임 분리를 직접 경험
-- 사용자 유형에 따라 API를 분리하고, 공통 기능은 모듈화하여 의존 흐름을 명확하게 설계
-- **대규모 트래픽을 고려한 실전 설계 훈련**
-- **지속 가능한 설계 → 확장 가능한 코드**를 고민하며 성장 중입니다

--- a/application.yml
+++ b/application.yml
@@ -71,12 +71,12 @@ resilience4j:
         retryExceptions:
           - com.reservation.support.exception.BusinessException
 
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
-    net.ttddyy.dsproxy.listener: DEBUG
-    com.github.gavlyukovskiy.boot.jdbc.decorator: DEBUG
+#logging:
+#  level:
+#    org.hibernate.SQL: debug
+#    org.hibernate.orm.jdbc.bind: trace
+#    net.ttddyy.dsproxy.listener: DEBUG
+#    com.github.gavlyukovskiy.boot.jdbc.decorator: DEBUG
 
 decorator:
   datasource:

--- a/client/customer/build.gradle
+++ b/client/customer/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
     implementation 'org.redisson:redisson-spring-boot-starter:3.48.0'
-    
+    implementation 'org.springframework.statemachine:spring-statemachine-core:4.0.0'
+
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'

--- a/client/customer/src/main/java/com/reservation/customer/payment/controller/PaymentController.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/controller/PaymentController.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.reservation.auth.annotation.LoginUserId;
 import com.reservation.customer.payment.controller.request.PaymentCheckRequest;
 import com.reservation.customer.payment.service.PaymentService;
 import com.reservation.customer.payment.service.dto.IamportPayment;
+import com.reservation.customer.payment.service.dto.PaymentCheckCommand;
 import com.reservation.support.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,9 +30,13 @@ public class PaymentController {
 	@PostMapping()
 	@Operation(summary = "결제 확인 API (결제 취소 시 낙관적 락 활용)", description = "결제가 정상적으로 처리 됐는지 확인합니다.")
 	@CrossOrigin(origins = "http://localhost:63342", allowCredentials = "true")
-	public ApiResponse<IamportPayment> optimisticValidationPayment(@RequestBody @Valid PaymentCheckRequest request) {
-		IamportPayment result =
-			paymentService.optimisticValidationPayment(request.paymentUid(), request.reservationId());
+	public ApiResponse<IamportPayment> optimisticValidationPayment(
+		@RequestBody @Valid PaymentCheckRequest request,
+		@LoginUserId long memberId
+	) {
+		PaymentCheckCommand command = request.validateAndToCommand(memberId);
+
+		IamportPayment result = paymentService.optimisticValidationPayment(command);
 
 		return ok(result);
 	}
@@ -38,9 +44,13 @@ public class PaymentController {
 	@PostMapping("redisson")
 	@Operation(summary = "결제 확인 API (결제 취소 시 레디슨 락 활용)", description = "결제가 정상적으로 처리 됐는지 확인합니다.")
 	@CrossOrigin(origins = "http://localhost:63342", allowCredentials = "true")
-	public ApiResponse<IamportPayment> redissonValidationPayment(@RequestBody @Valid PaymentCheckRequest request) {
-		IamportPayment result =
-			paymentService.redissonValidationPayment(request.paymentUid(), request.reservationId());
+	public ApiResponse<IamportPayment> redissonValidationPayment(
+		@RequestBody @Valid PaymentCheckRequest request,
+		@LoginUserId long memberId
+	) {
+		PaymentCheckCommand command = request.validateAndToCommand(memberId);
+
+		IamportPayment result = paymentService.redissonValidationPayment(command);
 
 		return ok(result);
 	}

--- a/client/customer/src/main/java/com/reservation/customer/payment/controller/request/PaymentCheckRequest.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/controller/request/PaymentCheckRequest.java
@@ -1,13 +1,57 @@
 package com.reservation.customer.payment.controller.request;
 
+import java.time.LocalDate;
+
+import com.reservation.customer.payment.service.dto.PaymentCheckCommand;
+import com.reservation.support.exception.ErrorCode;
+
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 
 public record PaymentCheckRequest(
 	@NotNull @NotEmpty
 	String paymentUid,
-	@NotNull @Positive
-	Long reservationId
+
+	@NotNull
+	Long roomTypeId,
+
+	@NotNull
+	LocalDate checkIn,
+
+	@NotNull
+	LocalDate checkOut,
+
+	@NotNull
+	String phoneNumber,
+
+	@NotNull
+	Integer guestsCount
 ) {
+	public PaymentCheckCommand validateAndToCommand(long memberId) {
+		if (paymentUid == null || paymentUid.isEmpty()) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Payment UID must not be empty");
+		}
+		if (roomTypeId == null || roomTypeId <= 0) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Room Type ID must be a positive number");
+		}
+		if (checkIn == null || checkOut == null || checkIn.isAfter(checkOut)) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Check-in and Check-out dates must be valid");
+		}
+		if (phoneNumber == null || phoneNumber.isEmpty()) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Phone number must not be empty");
+		}
+		if (guestsCount == null || guestsCount <= 0) {
+			throw ErrorCode.VALIDATION_ERROR.exception("Guests count must be a positive number");
+		}
+		
+		return new PaymentCheckCommand(
+			memberId,
+			paymentUid,
+			roomTypeId,
+			checkIn,
+			checkOut,
+			phoneNumber,
+			guestsCount
+		);
+	}
 }

--- a/client/customer/src/main/java/com/reservation/customer/payment/repository/JpaPaymentRepository.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/repository/JpaPaymentRepository.java
@@ -8,4 +8,6 @@ import com.reservation.domain.payment.Payment;
 
 public interface JpaPaymentRepository extends JpaRepository<Payment, Long> {
 	Optional<Payment> findByPaymentUid(String paymentUid);
+
+	Optional<Payment> findByReservationId(Long reservationId);
 }

--- a/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
@@ -115,6 +115,7 @@ public class PaymentService {
 
 		// 예약 완료
 		reservationRepository.save(optionalTemp.get().toReservation());
+		// Redis 예약 정보 삭제
 		redisTemplate.delete(key);
 
 		return iamportPayment;
@@ -227,8 +228,7 @@ public class PaymentService {
 					.build();
 
 				// 예약 가능 수량 원복
-				return optimisticCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(),
-					iamportPrice);
+				return redissonCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(), iamportPrice);
 			}
 
 			// 결제 완료
@@ -237,6 +237,7 @@ public class PaymentService {
 
 			// 예약 완료
 			reservationRepository.save(optionalTemp.get().toReservation());
+			// Redis 예약 정보 삭제
 			redisTemplate.delete(key);
 
 			return iamportPayment;

--- a/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/service/PaymentService.java
@@ -5,17 +5,22 @@ import static com.reservation.support.utils.retry.OptimisticLockingFailureRetryU
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.reservation.customer.payment.repository.JpaPaymentRepository;
 import com.reservation.customer.payment.service.dto.IamportPayment;
+import com.reservation.customer.payment.service.dto.PaymentCheckCommand;
 import com.reservation.customer.payment.service.iamport.Iamport;
 import com.reservation.customer.reservation.repository.JpaReservationRepository;
+import com.reservation.customer.reservation.service.RedisReservationStore;
+import com.reservation.customer.reservation.service.dto.TemporaryReservation;
 import com.reservation.customer.reservation.statemachine.ReservationStateMachineService;
 import com.reservation.customer.roomavailabilitysummary.repository.JpaRoomAvailabilitySummaryRepository;
 import com.reservation.domain.payment.Payment;
@@ -45,53 +50,63 @@ public class PaymentService {
 	private final JpaPaymentRepository paymentRepository;
 	private final JpaReservationRepository reservationRepository;
 	private final JpaRoomAvailabilitySummaryRepository jpaAvailabilitySummaryRepository;
+	private final RedisReservationStore redisReservationStore;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	private final RedissonClient redisson;
 
 	// 결제 검증 과정에서 낙관적 락을 사용하여 예약 가능 수량을 증가시키는 방식
 	@Transactional
-	public IamportPayment optimisticValidationPayment(String paymentUid, long reservationId) {
+	public IamportPayment optimisticValidationPayment(PaymentCheckCommand command) {
 		IamportPayment iamportPayment;
 
-		iamportPayment = new IamportPayment(iamport.paymentByImpUid(paymentUid));
+		iamportPayment = new IamportPayment(iamport.paymentByImpUid(command.paymentUid()));
 
 		// 결제 완료가 아니면
 		if (!iamportPayment.payment().getStatus().equals("paid")) {
 			throw ErrorCode.CONFLICT.exception("결제 미완료 상태입니다. 다시 결제해주세요");
 		}
 
-		// 예약 조회
-		Reservation reservation = reservationRepository.findById(reservationId)
-			.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약된 내역이 없습니다."));
-
-		// 결제해야할 예약 금액
-		int reservationTotalPrice = reservation.getTotalPrice();
 		// 실 결제 금액
 		int iamportPrice = iamportPayment.payment().getAmount().intValue();
 
+		// 결제 정보 생성
 		Payment payment = Payment.builder()
-			.paymentUid(paymentUid)
+			.paymentUid(command.paymentUid())
 			.price(iamportPrice)
 			.status(PaymentStatus.INITIATED)
 			.build();
 
-		// 만약 10분 초과로 이미 예약이 취소된 경우
-		if (reservation.getStatus().equals(ReservationStatus.EXPIRED)) {
-			// 이미 취소된 예약 -> 결제금액 취소(아임포트)
-			payment.markCancelled();
-			paymentRepository.save(payment);
-			return optimisticCancelPayment(reservation, iamportPayment.payment().getImpUid(), iamportPrice);
-		}
+		// Redis 조회
+		String key = String.format(
+			"reservation:%d:%d:%s:%s", command.memberId(), command.roomTypeId(), command.checkIn(), command.checkOut());
 
-		Integer iamportAmount = iamportPayment.payment().getAmount().intValue();
-		stateMachineService.sendEvent(reservation, iamportAmount, ReservationEvents.PAYMENT_FAILURE);
+		Optional<TemporaryReservation> optionalTemp = redisReservationStore.find(key);
 
-		// 만약 10분 초과로 이미 예약이 취소된 경우 또는 결제 금액이 맞지 않는 경우
-		if (iamportPrice != reservationTotalPrice) {
+		// Redis TTL 초과 => 유효하지 않은 예약 OR 결제 금액이 맞지 않는 경우
+		if (optionalTemp.isEmpty() || iamportPrice != optionalTemp.get().totalPrice()) {
 			// 결제금액 위변조로 의심 -> 결제금액 취소(아임포트) 및 예약 취소 & 예약 수량 원복
+			CancelData cancelData = new CancelData(command.paymentUid(), true, null); // 전체 금액 환불
+			iamport.cancelPaymentByImpUid(cancelData);
+
+			// 결제 취소 상태 저장
 			payment.markCancelled();
 			paymentRepository.save(payment);
-			return optimisticCancelPayment(reservation, iamportPayment.payment().getImpUid(), iamportPrice);
+
+			// 예약 오류 정보 생성
+			Reservation paidErrorReservation = Reservation.builder()
+				.roomTypeId(command.roomTypeId())
+				.memberId(command.memberId())
+				.checkOut(command.checkOut())
+				.checkIn(command.checkIn())
+				.status(ReservationStatus.PAID_ERROR)
+				.phoneNumber(command.phoneNumber())
+				.guestCount(command.guestsCount())
+				.totalPrice(iamportPrice)
+				.build();
+
+			// 예약 가능 수량 원복
+			return optimisticCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(), iamportPrice);
 		}
 
 		// 결제 완료
@@ -99,8 +114,9 @@ public class PaymentService {
 		paymentRepository.save(payment);
 
 		// 예약 완료
-		reservation.markPaid();
-		reservationRepository.save(reservation);
+		reservationRepository.save(optionalTemp.get().toReservation());
+		redisTemplate.delete(key);
+
 		return iamportPayment;
 	}
 
@@ -139,25 +155,33 @@ public class PaymentService {
 
 	// 결제 검증 과정에서 레디슨 락을 사용하여 예약 가능 수량을 증가시키는 방식
 	@Transactional
-	public IamportPayment redissonValidationPayment(String paymentUid, long reservationId) {
+	public IamportPayment redissonValidationPayment(PaymentCheckCommand command) {
 		IamportPayment iamportPayment;
 
-		iamportPayment = new IamportPayment(iamport.paymentByImpUid(paymentUid));
+		iamportPayment = new IamportPayment(iamport.paymentByImpUid(command.paymentUid()));
 
 		// 결제 완료가 아니면
 		if (!iamportPayment.payment().getStatus().equals("paid")) {
 			throw ErrorCode.CONFLICT.exception("결제 미완료 상태입니다. 다시 결제해주세요");
 		}
 
-		// 혹시 모를 데드락을 줄이기 위해, 멀티락 X -> 순서대로 락을 획득하는 방식으로 변경
-		// 비관적 락 처리 시작
-		Reservation reservation = reservationRepository.findById(reservationId)
-			.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약된 내역이 없습니다."));
-		RLock reservationLock = redisson.getLock("reservation:lock:" + reservationId);
+		// Redis 조회
+		String key = String.format(
+			"reservation:%d:%d:%s:%s", command.memberId(), command.roomTypeId(), command.checkIn(), command.checkOut());
+		Optional<TemporaryReservation> optionalTemp = redisReservationStore.find(key);
+
+		// 비관적 락 처리 시작 (혹시 모를 데드락을 줄이기 위해, 멀티락 X -> 순서대로 락을 획득하는 방식으로 변경)
+		String reservationLockKey = String.format(
+			"reservation:lock:%d:%d:%s:%s",
+			command.memberId(),
+			command.roomTypeId(),
+			command.checkIn(),
+			command.checkOut());
+		RLock reservationLock = redisson.getLock(reservationLockKey);
 		boolean isReservationLocked = false;
 
-		long roomTypeId = reservation.getRoomTypeId();
-		RLock checkInLock = redisson.getLock("reservation:lock:" + roomTypeId + ":" + reservation.getCheckIn());
+		long roomTypeId = command.roomTypeId();
+		RLock checkInLock = redisson.getLock("reservation:lock:" + roomTypeId + ":" + command.checkIn());
 		boolean isCheckInLock = false;
 
 		try {
@@ -171,32 +195,40 @@ public class PaymentService {
 				throw ErrorCode.CONFLICT.exception("해당 예약 건의 체크인 월은 현재 다른 결제 처리 중입니다. 잠시 후 다시 시도해 주세요.");
 			}
 
-			// 결제해야할 예약 금액
-			int reservationTotalPrice = reservation.getTotalPrice();
 			// 실 결제 금액
 			int iamportPrice = iamportPayment.payment().getAmount().intValue();
 
 			Payment payment = Payment.builder()
-				.paymentUid(paymentUid)
+				.paymentUid(command.paymentUid())
 				.price(iamportPrice)
 				.status(PaymentStatus.INITIATED)
 				.build();
 
-			// 10분 초과로 이미 예약이 취소된 경우
-			if (reservation.getStatus().equals(ReservationStatus.EXPIRED)) {
-				// 이미 취소된 예약 -> 결제금액 취소(아임포트)
-				payment.markCancelled();
-				paymentRepository.save(payment);
-				CancelData cancelData = new CancelData(paymentUid, true, new BigDecimal(iamportPrice));
-				return new IamportPayment(iamport.cancelPaymentByImpUid(cancelData));
-			}
-
-			// 결제 금액이 맞지 않는 경우
-			if (iamportPrice != reservationTotalPrice) {
+			// Redis TTL 초과 => 유효하지 않은 예약 OR 결제 금액이 맞지 않는 경우
+			if (optionalTemp.isEmpty() || iamportPrice != optionalTemp.get().totalPrice()) {
 				// 결제금액 위변조로 의심 -> 결제금액 취소(아임포트) 및 예약 취소 & 예약 수량 원복
+				CancelData cancelData = new CancelData(command.paymentUid(), true, null); // 전체 금액 환불
+				iamport.cancelPaymentByImpUid(cancelData);
+
+				// 결제 취소 상태 저장
 				payment.markCancelled();
 				paymentRepository.save(payment);
-				return redissonCancelPayment(reservation, iamportPayment.payment().getImpUid(), iamportPrice);
+
+				// 예약 오류 정보 생성
+				Reservation paidErrorReservation = Reservation.builder()
+					.roomTypeId(command.roomTypeId())
+					.memberId(command.memberId())
+					.checkOut(command.checkOut())
+					.checkIn(command.checkIn())
+					.status(ReservationStatus.PAID_ERROR)
+					.phoneNumber(command.phoneNumber())
+					.guestCount(command.guestsCount())
+					.totalPrice(iamportPrice)
+					.build();
+
+				// 예약 가능 수량 원복
+				return optimisticCancelPayment(paidErrorReservation, iamportPayment.payment().getImpUid(),
+					iamportPrice);
 			}
 
 			// 결제 완료
@@ -204,8 +236,9 @@ public class PaymentService {
 			paymentRepository.save(payment);
 
 			// 예약 완료
-			reservation.markPaid();
-			reservationRepository.save(reservation);
+			reservationRepository.save(optionalTemp.get().toReservation());
+			redisTemplate.delete(key);
+
 			return iamportPayment;
 		} catch (Exception e) {
 			log.error(e.getMessage());

--- a/client/customer/src/main/java/com/reservation/customer/payment/service/dto/PaymentCheckCommand.java
+++ b/client/customer/src/main/java/com/reservation/customer/payment/service/dto/PaymentCheckCommand.java
@@ -1,0 +1,14 @@
+package com.reservation.customer.payment.service.dto;
+
+import java.time.LocalDate;
+
+public record PaymentCheckCommand(
+	long memberId,
+	String paymentUid,
+	long roomTypeId,
+	LocalDate checkIn,
+	LocalDate checkOut,
+	String phoneNumber,
+	int guestsCount
+) {
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/controller/ReservationController.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/controller/ReservationController.java
@@ -4,9 +4,9 @@ import static com.reservation.support.response.ApiResponse.*;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,7 +57,7 @@ public class ReservationController {
 		return ok(result);
 	}
 
-	@PatchMapping("/{reservationId}/cancel")
+	@PutMapping("/{reservationId}/cancel")
 	@Operation(summary = "예약 취소 API", description = "결제 완료된 예약을 고객이 직접 취소합니다.")
 	public ApiResponse<Long> cancelReservation(
 		@LoginUserId long memberId,

--- a/client/customer/src/main/java/com/reservation/customer/reservation/controller/ReservationController.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/controller/ReservationController.java
@@ -4,6 +4,8 @@ import static com.reservation.support.response.ApiResponse.*;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,5 +55,16 @@ public class ReservationController {
 		CreateReservationResult result = reservationService.redissonCreateReservation(memberId, command);
 
 		return ok(result);
+	}
+
+	@PatchMapping("/{reservationId}/cancel")
+	@Operation(summary = "예약 취소 API", description = "결제 완료된 예약을 고객이 직접 취소합니다.")
+	public ApiResponse<Long> cancelReservation(
+		@LoginUserId long memberId,
+		@PathVariable Long reservationId
+	) {
+		reservationService.cancelReservation(memberId, reservationId);
+
+		return ok(reservationId);
 	}
 }

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/RedisReservationStore.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/RedisReservationStore.java
@@ -1,0 +1,42 @@
+package com.reservation.customer.reservation.service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.customer.reservation.service.dto.TemporaryReservation;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class RedisReservationStore {
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void save(TemporaryReservation reservation, Duration ttl) {
+		try {
+			String key = reservation.redisKey();
+			String value = objectMapper.writeValueAsString(reservation);
+			redisTemplate.opsForValue().set(key, value, ttl);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Redis 저장 중 JSON 직렬화 실패", e);
+		}
+	}
+
+	public Optional<TemporaryReservation> find(String key) {
+		String json = redisTemplate.opsForValue().get(key);
+		if (json == null)
+			return Optional.empty();
+
+		try {
+			return Optional.of(objectMapper.readValue(json, TemporaryReservation.class));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Redis 조회 중 JSON 역직렬화 실패", e);
+		}
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/ReservationService.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/ReservationService.java
@@ -2,8 +2,11 @@ package com.reservation.customer.reservation.service;
 
 import static com.reservation.support.utils.retry.OptimisticLockingFailureRetryUtils.*;
 
+import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RLock;
@@ -13,16 +16,27 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.reservation.customer.member.repository.JpaMemberRepository;
+import com.reservation.customer.payment.repository.JpaPaymentRepository;
+import com.reservation.customer.payment.service.iamport.Iamport;
+import com.reservation.customer.reservation.repository.JpaReservationRepository;
 import com.reservation.customer.reservation.service.dto.CreateReservationCommand;
 import com.reservation.customer.reservation.service.dto.CreateReservationResult;
 import com.reservation.customer.reservation.service.dto.TemporaryReservation;
+import com.reservation.customer.reservation.statemachine.ReservationStateMachineService;
+import com.reservation.customer.roomavailability.repository.JpaRoomAvailabilityRepository;
 import com.reservation.customer.roomavailabilitysummary.repository.JpaRoomAvailabilitySummaryRepository;
 import com.reservation.customer.roomavailabilitysummary.repository.RoomAvailabilitySummaryRepository;
 import com.reservation.customer.roomtype.repository.JpaRoomTypeRepository;
 import com.reservation.domain.member.Member;
+import com.reservation.domain.payment.Payment;
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+import com.reservation.domain.roomavailability.OriginRoomAvailability;
 import com.reservation.domain.roomavailabilitysummary.RoomAvailabilitySummary;
 import com.reservation.domain.roomtype.RoomType;
 import com.reservation.support.exception.ErrorCode;
+import com.siot.IamportRestClient.request.CancelData;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,10 +51,18 @@ public class ReservationService {
 
 	private static final int MAX_REDIS_RESERVATION_TTL_MINUTES = 10;
 
+	private final Iamport iamport;
+
+	private final ReservationStateMachineService stateMachineService;
+
 	private final JpaMemberRepository memberRepository;
 	private final JpaRoomAvailabilitySummaryRepository jpaAvailabilitySummaryRepository;
 	private final RoomAvailabilitySummaryRepository availabilitySummaryRepository;
 	private final JpaRoomTypeRepository roomTypeRepository;
+	private final JpaReservationRepository reservationRepository;
+	private final JpaRoomAvailabilityRepository roomAvailabilityRepository;
+	private final JpaPaymentRepository paymentRepository;
+
 	private final RedissonClient redisson;
 	private final RedisReservationStore redisReservationStore;
 
@@ -131,7 +153,6 @@ public class ReservationService {
 	 * - 총 숙박 요금 계산
 	 * - 임시 예약(PENDING) 생성
 	 */
-	@Transactional
 	public CreateReservationResult redissonCreateReservation(long memberId, CreateReservationCommand command) {
 		// 0. 회원 존재 여부 확인
 		Member member = memberRepository.findById(memberId)
@@ -141,40 +162,36 @@ public class ReservationService {
 		RoomType roomType = roomTypeRepository.findById(command.roomTypeId())
 			.orElseThrow(() -> ErrorCode.NOT_FOUND.exception("룸 타입이 존재하지 않습니다."));
 
+		// 혹시 모를 데드락을 줄이기 위해, 멀티락 X -> 순서대로 락을 획득하는 방식으로 변경
 		// 2. 비관적 락 처리 시작 (redisson 락 기반)
-		RLock checkInLock =
-			redisson.getLock("reservation:lock:" + command.roomTypeId() + ":" + command.checkIn());
-		boolean isCheckInLock = false;
+		YearMonth checkInMonth = YearMonth.from(command.checkIn());
+		YearMonth checkOutMonth = YearMonth.from(command.checkOut().minusDays(1));
+		RLock checkInMonthLock = redisson.getLock("reservation:lock:" + command.roomTypeId() + ":" + checkInMonth);
+		boolean isCheckInMonthLock = false;
+		RLock checkOutMonthLock = redisson.getLock("reservation:lock:" + command.roomTypeId() + ":" + checkOutMonth);
+		boolean isCheckOutMonthLock = false;
 		try {
-			isCheckInLock = checkInLock.tryLock(MAX_LOCK_WAIT_TIME_SECONDS, LOCK_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
-			if (!isCheckInLock) {
+			isCheckInMonthLock =
+				checkInMonthLock.tryLock(MAX_LOCK_WAIT_TIME_SECONDS, LOCK_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
+			if (!isCheckInMonthLock) {
 				throw ErrorCode.CONFLICT.exception("해당 객실은 현재 다른 예약 처리 중입니다. 잠시 후 다시 시도해 주세요.");
 			}
-
-			int requiredDayCount = (int)ChronoUnit.DAYS.between(command.checkIn(), command.checkOut());
+			if (!checkInMonth.equals(checkOutMonth)) {
+				isCheckOutMonthLock =
+					checkOutMonthLock.tryLock(MAX_LOCK_WAIT_TIME_SECONDS, LOCK_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
+				if (!isCheckOutMonthLock) {
+					throw ErrorCode.CONFLICT.exception("해당 예약 건의 체크아웃 월은 현재 다른 결제 처리 중입니다. 잠시 후 다시 시도해 주세요.");
+				}
+			}
 
 			// 3. 예약 가능 여부 확인
-			validateAvailability(command, requiredDayCount);
+			validateAvailability(command);
 
 			// 4. 수량 차감
-			RoomAvailabilitySummary availabilitySummary = decreaseAvailabilityCount(command, requiredDayCount);
+			decreaseAvailabilityCount(command);
 
 			// 5. 총 숙박 요금 계산
-			int totalPrice = availabilitySummary.getTotalPrice(requiredDayCount);
-
-			// Reservation 저장 대신 Redis TTL 저장
-			TemporaryReservation temp = new TemporaryReservation(
-				memberId,
-				command.roomTypeId(),
-				command.checkIn(),
-				command.checkOut(),
-				command.guestCount(),
-				member.getPhoneNumber(),
-				totalPrice
-			);
-
-			redisReservationStore.save(temp, Duration.ofMinutes(MAX_REDIS_RESERVATION_TTL_MINUTES));
-			log.info("임시 예약 저장 완료 - Redis key: {}", temp.redisKey());
+			int totalPrice = calculateTotalPrice(command);
 
 			return new CreateReservationResult(
 				member.getEmail(),
@@ -188,8 +205,112 @@ public class ReservationService {
 			log.error(e.getMessage());
 			throw ErrorCode.INTERNAL_SERVER_ERROR.exception("예약 처리 중 오류 발생");
 		} finally {
-			if (isCheckInLock) {
-				checkInLock.unlock();
+			if (isCheckOutMonthLock) {
+				checkOutMonthLock.unlock();
+			}
+			if (isCheckInMonthLock) {
+				checkInMonthLock.unlock();
+			}
+		}
+	}
+
+	private List<OriginRoomAvailability> decreaseAvailabilityCount(CreateReservationCommand command) {
+		List<OriginRoomAvailability> availabilities =
+			roomAvailabilityRepository.findAllByRoomTypeIdAndOpenDateBetween(
+				command.roomTypeId(), command.checkIn(), command.checkOut().minusDays(1)
+			);
+
+		if (availabilities.size() != ChronoUnit.DAYS.between(command.checkIn(), command.checkOut())) {
+			throw ErrorCode.CONFLICT.exception("예약 가능한 날짜 수량이 부족합니다.");
+		}
+
+		for (OriginRoomAvailability availability : availabilities) {
+			availability.decreaseAvailableCount(); // 내부에서 availableCount-- 및 예외 처리
+		}
+
+		// 버전 기반 낙관적 락으로 saveAll 시점에 충돌 검증
+		return roomAvailabilityRepository.saveAll(availabilities);
+	}
+
+	private void validateAvailability(CreateReservationCommand command) {
+		int requiredDayCount = (int)ChronoUnit.DAYS.between(command.checkIn(), command.checkOut());
+
+		long count = roomAvailabilityRepository.countByRoomTypeIdAndOpenDateBetweenAndAvailableCountGreaterThanEqual(
+			command.roomTypeId(), command.checkIn(), command.checkOut().minusDays(1), 1
+		);
+
+		if (count < requiredDayCount) {
+			throw ErrorCode.CONFLICT.exception("선택한 날짜에는 객실 예약이 불가능합니다.");
+		}
+	}
+
+	private int calculateTotalPrice(CreateReservationCommand command) {
+		return roomAvailabilityRepository.sumPriceByRoomTypeIdAndDateRange(
+			command.roomTypeId(), command.checkIn(), command.checkOut().minusDays(1)
+		);
+	}
+
+	@Transactional
+	public void cancelReservation(long memberId, Long reservationId) {
+		// 1. 예약 조회
+		Reservation reservation = reservationRepository.findById(reservationId)
+			.orElseThrow(() -> ErrorCode.NOT_FOUND.exception("예약 정보를 찾을 수 없습니다."));
+
+		// 2. 본인 예약인지 확인
+		if (!reservation.getMemberId().equals(memberId)) {
+			throw ErrorCode.FORBIDDEN.exception("본인의 예약만 취소할 수 있습니다.");
+		}
+
+		// 3. 결제 완료 상태인지 확인
+		if (reservation.getStatus() != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("결제 완료된 예약만 취소할 수 있습니다.");
+		}
+
+		String lockKey = "reservation:lock:" + reservation.getRoomTypeId() + ":" + reservation.getCheckIn();
+		RLock lock = redisson.getLock(lockKey);
+		boolean locked = false;
+
+		try {
+			locked = lock.tryLock(MAX_LOCK_WAIT_TIME_SECONDS, LOCK_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
+			if (!locked) {
+				throw ErrorCode.CONFLICT.exception("해당 예약 수량 복구 중 다른 요청이 처리 중입니다.");
+			}
+
+			// 4. 상태머신: 고객 취소 요청
+			stateMachineService.sendEvent(reservation, ReservationEvents.CUSTOMER_PAYMENT_CANCEL);
+
+			// 5. 아임포트 결제 취소
+			Payment payment = paymentRepository.findByReservationId(reservationId)
+				.orElseThrow(() -> ErrorCode.NOT_FOUND.exception("결제 정보가 없습니다."));
+
+			iamport.cancelPaymentByImpUid(
+				new CancelData(payment.getPaymentUid(), true, new BigDecimal(payment.getPrice()))
+			);
+			payment.markCancelled();
+			paymentRepository.save(payment);
+
+			// 6. 상태머신: PG 결제 취소 성공 처리
+			stateMachineService.sendEvent(reservation, ReservationEvents.PG_PAID_CANCEL);
+
+			// 7. 예약 가능 수량 복구
+			RoomAvailabilitySummary summary = jpaAvailabilitySummaryRepository
+				.findOneByRoomTypeIdAndCheckInDate(reservation.getRoomTypeId(), reservation.getCheckIn())
+				.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약 가능 수량 정보가 없습니다."));
+
+			int days = (int)ChronoUnit.DAYS.between(reservation.getCheckIn(), reservation.getCheckOut());
+			summary.increaseAvailability(days);
+			summary.prePersist();
+			jpaAvailabilitySummaryRepository.save(summary);
+
+			// 8. 최종 예약 저장
+			reservationRepository.save(reservation);
+
+		} catch (Exception e) {
+			log.error(e.getMessage());
+			throw ErrorCode.CONFLICT.exception("예약 취소 처리 중 오류 발생");
+		} finally {
+			if (locked) {
+				lock.unlock();
 			}
 		}
 	}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationResult.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/CreateReservationResult.java
@@ -1,13 +1,9 @@
 package com.reservation.customer.reservation.service.dto;
 
-import com.reservation.domain.reservation.enums.ReservationStatus;
-
 public record CreateReservationResult(
-	Long reservationId,
 	String memberEmail,
 	String memberPhoneNumber,
 	String roomTypeName,
-	ReservationStatus status,
 	int totalPrice,
 	String impUid
 ) {

--- a/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/TemporaryReservation.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/service/dto/TemporaryReservation.java
@@ -1,0 +1,35 @@
+package com.reservation.customer.reservation.service.dto;
+
+import java.time.LocalDate;
+
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+public record TemporaryReservation(
+	Long memberId,
+	Long roomTypeId,
+	LocalDate checkIn,
+	LocalDate checkOut,
+	int guestCount,
+	String phoneNumber,
+	int totalPrice
+) {
+	public String redisKey() {
+		return String.format("reservation:%d:%d:%s:%s",
+			memberId, roomTypeId, checkIn, checkOut
+		);
+	}
+
+	public Reservation toReservation() {
+		return Reservation.builder()
+			.roomTypeId(roomTypeId)
+			.memberId(memberId)
+			.checkIn(checkIn)
+			.checkOut(checkOut)
+			.guestCount(guestCount)
+			.phoneNumber(phoneNumber)
+			.totalPrice(totalPrice)
+			.status(ReservationStatus.PAID) // 결제 검증 성공
+			.build();
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/ReservationStateMachineService.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/ReservationStateMachineService.java
@@ -1,0 +1,67 @@
+package com.reservation.customer.reservation.statemachine;
+
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.support.DefaultStateMachineContext;
+import org.springframework.stereotype.Service;
+
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class ReservationStateMachineService {
+
+	private final StateMachineFactory<ReservationStatus, ReservationEvents> factory;
+
+	public void sendEvent(Reservation reservation, ReservationEvents event) {
+		StateMachine<ReservationStatus, ReservationEvents> stateMachine =
+			factory.getStateMachine(reservation.getId().toString());
+
+		stateMachine.start();
+
+		stateMachine.getStateMachineAccessor()
+			.doWithAllRegions(access -> {
+				access.resetStateMachine(
+					new DefaultStateMachineContext<>(reservation.getStatus(), null, null, null)
+				);
+			});
+
+		stateMachine.sendEvent(
+			MessageBuilder
+				.withPayload(event)
+				.setHeader("reservation", reservation) // 필요 시 액션에서 접근 가능
+				.build()
+		);
+
+		stateMachine.stop();
+	}
+
+	public void sendEvent(Reservation reservation, Integer iamportAmount, ReservationEvents event) {
+		StateMachine<ReservationStatus, ReservationEvents> stateMachine =
+			factory.getStateMachine(reservation.getId().toString());
+
+		stateMachine.start();
+
+		stateMachine.getStateMachineAccessor()
+			.doWithAllRegions(access -> {
+				access.resetStateMachine(
+					new DefaultStateMachineContext<>(reservation.getStatus(), null, null, null)
+				);
+			});
+
+		stateMachine.sendEvent(
+			MessageBuilder
+				.withPayload(event)
+				.setHeader("reservation", reservation) // 필요 시 액션에서 접근 가능
+				.setHeader("iamportAmount", iamportAmount) // 필요 시 액션에서 접근 가능
+				.build()
+		);
+
+		stateMachine.stop();
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
@@ -1,0 +1,157 @@
+package com.reservation.customer.reservation.statemachine;
+
+import static com.reservation.domain.reservation.enums.ReservationEvents.*;
+import static com.reservation.domain.reservation.enums.ReservationStatus.*;
+import static com.reservation.domain.reservation.enums.ReservationStatus.PG_CANCEL_FAIL;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.config.EnableStateMachineFactory;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+import org.springframework.statemachine.guard.Guard;
+
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableStateMachineFactory
+// @EnableStateMachine
+@RequiredArgsConstructor
+public class StateMachineConfig extends StateMachineConfigurerAdapter<ReservationStatus, ReservationEvents> {
+
+	private final Action<ReservationStatus, ReservationEvents> markPaidErrorAction;
+	private final Guard<ReservationStatus, ReservationEvents> isPaymentAmountValidGuard;
+	private final Action<ReservationStatus, ReservationEvents> markPaidAction;
+	private final Guard<ReservationStatus, ReservationEvents> isPaymentAmountInvalidGuard;
+	private final Action<ReservationStatus, ReservationEvents> markExpiredAction;
+	private final Action<ReservationStatus, ReservationEvents> markConfirmedAction;
+	private final Action<ReservationStatus, ReservationEvents> markPaidErrorCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markPgCancelFailAction;
+	private final Action<ReservationStatus, ReservationEvents> markCustomerCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markAdminCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markHostRejectedAction;
+	private final Action<ReservationStatus, ReservationEvents> markCustomerPaidCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markAdminPaidCanceledAction;
+	private final Action<ReservationStatus, ReservationEvents> markHostPaidCanceledAction;
+
+	@Override
+	public void configure(StateMachineStateConfigurer<ReservationStatus, ReservationEvents> states) throws Exception {
+		states
+			.withStates()
+			.initial(PENDING) // 초기 상태
+			.state(ReservationStatus.EXPIRED) // 결제 시간 초과 상태
+			.state(ReservationStatus.PAID) // 결제 완료 상태
+			.state(ReservationStatus.PAID_ERROR) // 결제 에러 상태
+			.state(ReservationStatus.CUSTOMER_CANCELED) // 사용자 취소 상태
+			.state(ReservationStatus.HOST_REJECTED) // 호스트 거절 상태
+			.state(ReservationStatus.ADMIN_CANCELED) // 관리자 취소 상태
+			.state(ReservationStatus.CONFIRMED) // 예약 확정 상태
+			.state(ReservationStatus.PAID_ERROR_CANCELED) // 결제 에러로 인한 결제 취소 상태
+			.state(ReservationStatus.CUSTOMER_PAID_CANCELED) // 사용자 취소로 인한 결제 취소 상태
+			.state(ReservationStatus.ADMIN_PAID_CANCELED) // 관리자 취소로 인한 결제 취소 상태
+			.state(ReservationStatus.HOST_PAID_CANCELED) // 호스트 거절로 인한 결제 취소 상태
+			.state(ReservationStatus.PG_VALIDATE_ERROR) // PG 검증 실패 상태
+			.state(ReservationStatus.PG_CANCEL_FAIL); // PG 결제 취소 실패 상태
+	}
+
+	@Override
+	public void configure(
+		StateMachineTransitionConfigurer<ReservationStatus, ReservationEvents> transitions
+	) throws Exception {
+		transitions
+			// PENDING → 결제 성공/실패 분기
+			.withExternal()
+			.source(PENDING).target(PAID) // 펜딩에서 -> 결제 완료로
+			.event(VALIDATE_PAYMENT) // 이벤트: 결제 검증
+			.guard(isPaymentAmountValidGuard) // 가드: 결제 금액이 일치하면
+			.action(markPaidAction) // 액션: 결제 완료로 상태 변경
+
+			.and()
+			.withExternal()
+			.source(PENDING).target(PAID_ERROR) // 펜딩에서 -> 결제 에러로
+			.event(VALIDATE_PAYMENT) // 이벤트: 결제 검증
+			.guard(isPaymentAmountInvalidGuard) // 가드: 결제 금액이 불일치하면
+			.action(markPaidErrorAction) // 액션: 결제 에러로 상태 변경
+
+			.and()
+			.withExternal().source(PENDING).target(PG_VALIDATE_ERROR) // 펜딩에서 -> PG 검증 에러로
+			.event(PAYMENT_VALIDATE_ERROR)
+			.action(markPaidErrorAction)
+			.and()
+			.withExternal().source(PENDING).target(EXPIRED)
+			.event(PAYMENT_EXPIRED)
+			.action(markExpiredAction)
+
+			// PG_VALIDATE_ERROR → 재검증
+			.and()
+			.withExternal().source(PG_VALIDATE_ERROR).target(PAID)
+			.event(PAYMENT_SUCCESS)
+			.guard(isPaymentAmountValidGuard)
+			.action(markPaidAction)
+			.and()
+			.withExternal().source(PG_VALIDATE_ERROR).target(PAID_ERROR)
+			.event(PAYMENT_SUCCESS)
+			.guard(isPaymentAmountInvalidGuard)
+			.action(markPaidErrorAction)
+
+			// PAID → 확정
+			.and()
+			.withExternal().source(PAID).target(CONFIRMED)
+			.event(CHECKIN_PASSED)
+			.action(markConfirmedAction)
+
+			// PAID_ERROR → 결제 취소 or 실패
+			.and()
+			.withExternal().source(PAID_ERROR).target(PAID_ERROR_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markPaidErrorCanceledAction)
+			.and()
+			.withExternal().source(PAID_ERROR).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction)
+
+			// PAID → 취소 요청
+			.and()
+			.withExternal().source(PAID).target(CUSTOMER_CANCELED)
+			.event(CUSTOMER_PAYMENT_CANCEL)
+			.action(markCustomerCanceledAction)
+			.and()
+			.withExternal().source(PAID).target(ADMIN_CANCELED)
+			.event(ADMIN_PAYMENT_CANCEL)
+			.action(markAdminCanceledAction)
+			.and()
+			.withExternal().source(PAID).target(HOST_REJECTED)
+			.event(HOST_PAYMENT_CANCEL)
+			.action(markHostRejectedAction)
+
+			// 취소 → 결제 취소 or 실패
+			.and()
+			.withExternal().source(CUSTOMER_CANCELED).target(CUSTOMER_PAID_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markCustomerPaidCanceledAction)
+			.and()
+			.withExternal().source(CUSTOMER_CANCELED).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction)
+			.and()
+			.withExternal().source(ADMIN_CANCELED).target(ADMIN_PAID_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markAdminPaidCanceledAction)
+			.and()
+			.withExternal().source(ADMIN_CANCELED).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction)
+			.and()
+			.withExternal().source(HOST_REJECTED).target(HOST_PAID_CANCELED)
+			.event(PG_PAID_CANCEL)
+			.action(markHostPaidCanceledAction)
+			.and()
+			.withExternal().source(HOST_REJECTED).target(PG_CANCEL_FAIL)
+			.event(ReservationEvents.PG_CANCEL_FAIL)
+			.action(markPgCancelFailAction);
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/StateMachineConfig.java
@@ -46,14 +46,10 @@ public class StateMachineConfig extends StateMachineConfigurerAdapter<Reservatio
 			.state(ReservationStatus.EXPIRED) // 결제 시간 초과 상태
 			.state(ReservationStatus.PAID) // 결제 완료 상태
 			.state(ReservationStatus.PAID_ERROR) // 결제 에러 상태
-			.state(ReservationStatus.CUSTOMER_CANCELED) // 사용자 취소 상태
-			.state(ReservationStatus.HOST_REJECTED) // 호스트 거절 상태
-			.state(ReservationStatus.ADMIN_CANCELED) // 관리자 취소 상태
+			.state(ReservationStatus.CANCELED) // 예약 취소 상태
 			.state(ReservationStatus.CONFIRMED) // 예약 확정 상태
 			.state(ReservationStatus.PAID_ERROR_CANCELED) // 결제 에러로 인한 결제 취소 상태
-			.state(ReservationStatus.CUSTOMER_PAID_CANCELED) // 사용자 취소로 인한 결제 취소 상태
-			.state(ReservationStatus.ADMIN_PAID_CANCELED) // 관리자 취소로 인한 결제 취소 상태
-			.state(ReservationStatus.HOST_PAID_CANCELED) // 호스트 거절로 인한 결제 취소 상태
+			.state(ReservationStatus.PAID_CANCELED) // 결제 취소 상태
 			.state(ReservationStatus.PG_VALIDATE_ERROR) // PG 검증 실패 상태
 			.state(ReservationStatus.PG_CANCEL_FAIL); // PG 결제 취소 실패 상태
 	}
@@ -116,41 +112,41 @@ public class StateMachineConfig extends StateMachineConfigurerAdapter<Reservatio
 
 			// PAID → 취소 요청
 			.and()
-			.withExternal().source(PAID).target(CUSTOMER_CANCELED)
+			.withExternal().source(PAID).target(CANCELED)
 			.event(CUSTOMER_PAYMENT_CANCEL)
 			.action(markCustomerCanceledAction)
 			.and()
-			.withExternal().source(PAID).target(ADMIN_CANCELED)
+			.withExternal().source(PAID).target(CANCELED)
 			.event(ADMIN_PAYMENT_CANCEL)
 			.action(markAdminCanceledAction)
 			.and()
-			.withExternal().source(PAID).target(HOST_REJECTED)
+			.withExternal().source(PAID).target(CANCELED)
 			.event(HOST_PAYMENT_CANCEL)
 			.action(markHostRejectedAction)
 
 			// 취소 → 결제 취소 or 실패
 			.and()
-			.withExternal().source(CUSTOMER_CANCELED).target(CUSTOMER_PAID_CANCELED)
+			.withExternal().source(CANCELED).target(PAID_CANCELED)
 			.event(PG_PAID_CANCEL)
 			.action(markCustomerPaidCanceledAction)
 			.and()
-			.withExternal().source(CUSTOMER_CANCELED).target(PG_CANCEL_FAIL)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(ReservationEvents.PG_CANCEL_FAIL)
 			.action(markPgCancelFailAction)
 			.and()
-			.withExternal().source(ADMIN_CANCELED).target(ADMIN_PAID_CANCELED)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(PG_PAID_CANCEL)
 			.action(markAdminPaidCanceledAction)
 			.and()
-			.withExternal().source(ADMIN_CANCELED).target(PG_CANCEL_FAIL)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(ReservationEvents.PG_CANCEL_FAIL)
 			.action(markPgCancelFailAction)
 			.and()
-			.withExternal().source(HOST_REJECTED).target(HOST_PAID_CANCELED)
+			.withExternal().source(CANCELED).target(PAID_CANCELED)
 			.event(PG_PAID_CANCEL)
 			.action(markHostPaidCanceledAction)
 			.and()
-			.withExternal().source(HOST_REJECTED).target(PG_CANCEL_FAIL)
+			.withExternal().source(CANCELED).target(PG_CANCEL_FAIL)
 			.event(ReservationEvents.PG_CANCEL_FAIL)
 			.action(markPgCancelFailAction);
 	}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
@@ -118,7 +118,7 @@ public class ReservationActionConfig {
 	}
 
 	@Bean
-	public Action<ReservationStatus, ReservationEvents> markCustomerCanceledAction() {
+	public Action<ReservationStatus, ReservationEvents> markCanceledAction() {
 		return context -> {
 			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
 			if (reservation == null) {
@@ -127,8 +127,8 @@ public class ReservationActionConfig {
 			}
 			ReservationStatus from = reservation.getStatus();
 
-			reservation.markCustomerCanceled();
-			log.info("예약 [{}] 상태를 'markCustomerCanceled'로 전환합니다.", reservation.getId());
+			reservation.markCanceled();
+			log.info("예약 [{}] 상태를 'markCanceled'로 전환합니다.", reservation.getId());
 
 			ReservationStatus to = reservation.getStatus();
 
@@ -141,7 +141,7 @@ public class ReservationActionConfig {
 	}
 
 	@Bean
-	public Action<ReservationStatus, ReservationEvents> markAdminCanceledAction() {
+	public Action<ReservationStatus, ReservationEvents> markPaidCanceledAction() {
 		return context -> {
 			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
 			if (reservation == null) {
@@ -150,100 +150,8 @@ public class ReservationActionConfig {
 			}
 			ReservationStatus from = reservation.getStatus();
 
-			reservation.markAdminCanceled();
-			log.info("예약 [{}] 상태를 'markAdminCanceled'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markHostRejectedAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markHostRejected();
-			log.info("예약 [{}] 상태를 'markHostRejected'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markCustomerPaidCanceledAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markCustomerPaidCanceled();
-			log.info("예약 [{}] 상태를 'markCustomerPaidCanceled'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markAdminPaidCanceledAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markAdminPaidCanceled();
-			log.info("예약 [{}] 상태를 'markAdminPaidCanceled'로 전환합니다.", reservation.getId());
-
-			ReservationStatus to = reservation.getStatus();
-
-			historyRepository.save(ReservationStatusHistory.builder()
-				.reservationId(reservation.getId())
-				.fromStatus(from)
-				.toStatus(to)
-				.build());
-		};
-	}
-
-	@Bean
-	public Action<ReservationStatus, ReservationEvents> markHostPaidCanceledAction() {
-		return context -> {
-			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
-			if (reservation == null) {
-				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
-				return;
-			}
-			ReservationStatus from = reservation.getStatus();
-
-			reservation.markHostPaidCanceled();
-			log.info("예약 [{}] 상태를 'markHostPaidCanceled'로 전환합니다.", reservation.getId());
+			reservation.markPaidCanceled();
+			log.info("예약 [{}] 상태를 'markPaidCanceled'로 전환합니다.", reservation.getId());
 
 			ReservationStatus to = reservation.getStatus();
 

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/action/ReservationActionConfig.java
@@ -1,0 +1,313 @@
+package com.reservation.customer.reservation.statemachine.action;
+
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.reservation.customer.reservationstatushistory.repository.ReservationStatusHistoryRepository;
+import com.reservation.customer.roomavailabilitysummary.repository.JpaRoomAvailabilitySummaryRepository;
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+import com.reservation.domain.reservationstatushistory.ReservationStatusHistory;
+import com.reservation.domain.roomavailabilitysummary.RoomAvailabilitySummary;
+import com.reservation.support.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ReservationActionConfig {
+	private final ReservationStatusHistoryRepository historyRepository;
+	private final JpaRoomAvailabilitySummaryRepository jpaAvailabilitySummaryRepository;
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPaidAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPaid();
+			log.info("예약 [{}] 상태를 'markPaid'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPaidErrorAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPaidError();
+			log.info("예약 [{}] 상태를 'markPaidError'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markExpiredAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markExpired();
+			log.info("예약 [{}] 상태를 'markExpired'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markConfirmedAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markConfirmed();
+			log.info("예약 [{}] 상태를 'markConfirmed'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markCustomerCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markCustomerCanceled();
+			log.info("예약 [{}] 상태를 'markCustomerCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markAdminCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markAdminCanceled();
+			log.info("예약 [{}] 상태를 'markAdminCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markHostRejectedAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markHostRejected();
+			log.info("예약 [{}] 상태를 'markHostRejected'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markCustomerPaidCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markCustomerPaidCanceled();
+			log.info("예약 [{}] 상태를 'markCustomerPaidCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markAdminPaidCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markAdminPaidCanceled();
+			log.info("예약 [{}] 상태를 'markAdminPaidCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markHostPaidCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markHostPaidCanceled();
+			log.info("예약 [{}] 상태를 'markHostPaidCanceled'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPaidErrorCanceledAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPaidErrorCanceled();
+			log.info("예약 [{}] 상태를 'markPaidErrorCanceled'로 전환합니다.", reservation.getId());
+
+			// ✅ 예약 가능 수량 원복
+			RoomAvailabilitySummary summary = jpaAvailabilitySummaryRepository
+				.findOneByRoomTypeIdAndCheckInDate(reservation.getRoomTypeId(), reservation.getCheckIn())
+				.orElseThrow(() -> ErrorCode.CONFLICT.exception("예약 가능 수량이 없습니다."));
+
+			int days = (int)ChronoUnit.DAYS.between(reservation.getCheckIn(), reservation.getCheckOut());
+			summary.increaseAvailability(days);
+			summary.prePersist();
+			jpaAvailabilitySummaryRepository.save(summary);
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+
+	@Bean
+	public Action<ReservationStatus, ReservationEvents> markPgCancelFailAction() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			if (reservation == null) {
+				log.error("Reservation 객체가 Action에 전달되지 않았습니다.");
+				return;
+			}
+			ReservationStatus from = reservation.getStatus();
+
+			reservation.markPgCancelFail();
+			log.info("예약 [{}] 상태를 'markPgCancelFail'로 전환합니다.", reservation.getId());
+
+			ReservationStatus to = reservation.getStatus();
+
+			historyRepository.save(ReservationStatusHistory.builder()
+				.reservationId(reservation.getId())
+				.fromStatus(from)
+				.toStatus(to)
+				.build());
+		};
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/guard/ReservationGuardConfig.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservation/statemachine/guard/ReservationGuardConfig.java
@@ -1,0 +1,35 @@
+package com.reservation.customer.reservation.statemachine.guard;
+
+import java.util.Objects;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.guard.Guard;
+
+import com.reservation.domain.reservation.Reservation;
+import com.reservation.domain.reservation.enums.ReservationEvents;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+@Configuration
+public class ReservationGuardConfig {
+
+	@Bean
+	public Guard<ReservationStatus, ReservationEvents> isPaymentAmountValidGuard() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			Integer iamportPrice = (Integer)context.getMessageHeader("paidAmount");
+
+			return Objects.equals(reservation.getTotalPrice(), iamportPrice);
+		};
+	}
+
+	@Bean
+	public Guard<ReservationStatus, ReservationEvents> isPaymentAmountInvalidGuard() {
+		return context -> {
+			Reservation reservation = (Reservation)context.getMessageHeader("reservation");
+			Integer iamportPrice = (Integer)context.getMessageHeader("paidAmount");
+            
+			return !Objects.equals(reservation.getTotalPrice(), iamportPrice);
+		};
+	}
+}

--- a/client/customer/src/main/java/com/reservation/customer/reservationstatushistory/repository/ReservationStatusHistoryRepository.java
+++ b/client/customer/src/main/java/com/reservation/customer/reservationstatushistory/repository/ReservationStatusHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.reservation.customer.reservationstatushistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.reservation.domain.reservationstatushistory.ReservationStatusHistory;
+
+@Repository
+public interface ReservationStatusHistoryRepository extends JpaRepository<ReservationStatusHistory, Long> {
+}

--- a/core/domain/src/main/java/com/reservation/domain/payment/Payment.java
+++ b/core/domain/src/main/java/com/reservation/domain/payment/Payment.java
@@ -24,6 +24,9 @@ public class Payment extends BaseEntity {
 	@Column(nullable = false)
 	private String paymentUid;
 
+	@Column(nullable = false)
+	private Long reservationId;
+
 	@Builder
 	public Payment(Integer price, PaymentStatus status, String paymentUid) {
 		if (price == null || price < 0) {

--- a/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
@@ -111,46 +111,18 @@ public class Reservation extends BaseEntity {
 		return this.status == ReservationStatus.PENDING;
 	}
 
-	public void markCustomerCanceled() {
+	public void markCanceled() {
 		if (this.status != ReservationStatus.PAID) {
-			throw ErrorCode.BAD_REQUEST.exception("사용자 취소는 결제 완료 상태에서만 가능합니다.");
+			throw ErrorCode.BAD_REQUEST.exception("취소는 결제 완료 상태에서만 가능합니다.");
 		}
-		this.status = ReservationStatus.CUSTOMER_CANCELED;
+		this.status = ReservationStatus.CANCELED;
 	}
 
-	public void markAdminCanceled() {
-		if (this.status != ReservationStatus.PAID) {
-			throw ErrorCode.BAD_REQUEST.exception("관리자 취소는 결제 완료 상태에서만 가능합니다.");
+	public void markPaidCanceled() {
+		if (this.status != ReservationStatus.CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("결제 취소는 취소 상태에서만 가능합니다.");
 		}
-		this.status = ReservationStatus.ADMIN_CANCELED;
-	}
-
-	public void markHostRejected() {
-		if (this.status != ReservationStatus.PAID) {
-			throw ErrorCode.BAD_REQUEST.exception("호스트 거절은 결제 완료 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.HOST_REJECTED;
-	}
-
-	public void markCustomerPaidCanceled() {
-		if (this.status != ReservationStatus.CUSTOMER_CANCELED) {
-			throw ErrorCode.BAD_REQUEST.exception("사용자 결제 취소는 사용자 취소 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.CUSTOMER_PAID_CANCELED;
-	}
-
-	public void markAdminPaidCanceled() {
-		if (this.status != ReservationStatus.ADMIN_CANCELED) {
-			throw ErrorCode.BAD_REQUEST.exception("관리자 결제 취소는 관리자 취소 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.ADMIN_PAID_CANCELED;
-	}
-
-	public void markHostPaidCanceled() {
-		if (this.status != ReservationStatus.HOST_REJECTED) {
-			throw ErrorCode.BAD_REQUEST.exception("호스트 결제 취소는 호스트 거절 상태에서만 가능합니다.");
-		}
-		this.status = ReservationStatus.HOST_PAID_CANCELED;
+		this.status = ReservationStatus.PAID_CANCELED;
 	}
 
 	public void markPaidErrorCanceled() {
@@ -161,9 +133,8 @@ public class Reservation extends BaseEntity {
 	}
 
 	public void markPgCancelFail() {
-		if (this.status != ReservationStatus.PAID_ERROR && this.status != ReservationStatus.CUSTOMER_CANCELED &&
-			this.status != ReservationStatus.ADMIN_CANCELED && this.status != ReservationStatus.HOST_REJECTED) {
-			throw ErrorCode.BAD_REQUEST.exception("PG 결제 취소 실패는 결제 에러, 사용자 취소, 관리자 취소, 호스트 거절 상태에서만 가능합니다.");
+		if (this.status != ReservationStatus.PAID_ERROR && this.status != ReservationStatus.CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("PG 결제 취소 실패는 결제 에러, 또는 취소 상태에서만 가능합니다.");
 		}
 		this.status = ReservationStatus.PG_CANCEL_FAIL;
 	}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
@@ -88,7 +88,7 @@ public class Reservation extends BaseEntity {
 		this.guestCount = guestCount;
 		this.phoneNumber = phoneNumber;
 		this.totalPrice = totalPrice;
-		this.status = status != null ? status : ReservationStatus.PENDING;
+		this.status = status != null ? status : ReservationStatus.CANCELED;
 	}
 
 	public void markConfirmed() {
@@ -101,14 +101,6 @@ public class Reservation extends BaseEntity {
 
 	public void markPaidError() {
 		this.status = ReservationStatus.PAID_ERROR;
-	}
-
-	public void markExpired() {
-		this.status = ReservationStatus.EXPIRED;
-	}
-
-	public boolean isPending() {
-		return this.status == ReservationStatus.PENDING;
 	}
 
 	public void markCanceled() {

--- a/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/Reservation.java
@@ -95,8 +95,12 @@ public class Reservation extends BaseEntity {
 		this.status = ReservationStatus.CONFIRMED;
 	}
 
-	public void markCanceled() {
-		this.status = ReservationStatus.CANCELED;
+	public void markPaid() {
+		this.status = ReservationStatus.PAID;
+	}
+
+	public void markPaidError() {
+		this.status = ReservationStatus.PAID_ERROR;
 	}
 
 	public void markExpired() {
@@ -105,5 +109,62 @@ public class Reservation extends BaseEntity {
 
 	public boolean isPending() {
 		return this.status == ReservationStatus.PENDING;
+	}
+
+	public void markCustomerCanceled() {
+		if (this.status != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("사용자 취소는 결제 완료 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.CUSTOMER_CANCELED;
+	}
+
+	public void markAdminCanceled() {
+		if (this.status != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("관리자 취소는 결제 완료 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.ADMIN_CANCELED;
+	}
+
+	public void markHostRejected() {
+		if (this.status != ReservationStatus.PAID) {
+			throw ErrorCode.BAD_REQUEST.exception("호스트 거절은 결제 완료 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.HOST_REJECTED;
+	}
+
+	public void markCustomerPaidCanceled() {
+		if (this.status != ReservationStatus.CUSTOMER_CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("사용자 결제 취소는 사용자 취소 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.CUSTOMER_PAID_CANCELED;
+	}
+
+	public void markAdminPaidCanceled() {
+		if (this.status != ReservationStatus.ADMIN_CANCELED) {
+			throw ErrorCode.BAD_REQUEST.exception("관리자 결제 취소는 관리자 취소 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.ADMIN_PAID_CANCELED;
+	}
+
+	public void markHostPaidCanceled() {
+		if (this.status != ReservationStatus.HOST_REJECTED) {
+			throw ErrorCode.BAD_REQUEST.exception("호스트 결제 취소는 호스트 거절 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.HOST_PAID_CANCELED;
+	}
+
+	public void markPaidErrorCanceled() {
+		if (this.status != ReservationStatus.PAID_ERROR) {
+			throw ErrorCode.BAD_REQUEST.exception("결제 에러 취소는 결제 에러 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.PAID_ERROR_CANCELED;
+	}
+
+	public void markPgCancelFail() {
+		if (this.status != ReservationStatus.PAID_ERROR && this.status != ReservationStatus.CUSTOMER_CANCELED &&
+			this.status != ReservationStatus.ADMIN_CANCELED && this.status != ReservationStatus.HOST_REJECTED) {
+			throw ErrorCode.BAD_REQUEST.exception("PG 결제 취소 실패는 결제 에러, 사용자 취소, 관리자 취소, 호스트 거절 상태에서만 가능합니다.");
+		}
+		this.status = ReservationStatus.PG_CANCEL_FAIL;
 	}
 }

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationEvents.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationEvents.java
@@ -1,0 +1,40 @@
+package com.reservation.domain.reservation.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ReservationEvents {
+	// 결제 흐름
+	VALIDATE_PAYMENT("결제 검증 요청", "PG에서 결제 금액을 조회하고 검증을 수행"),
+
+	PAYMENT_SUCCESS("결제 성공", "결제 완료"),
+	PAYMENT_FAILURE("결제 실패", "결제 금액 불일치"),
+	PAYMENT_VALIDATE_ERROR("PG 검증 실패", "PG 통신 실패"),
+	PAYMENT_EXPIRED("결제 만료", "결제 시간 초과"),
+
+	// 체크인 흐름
+	CHECKIN_PASSED("체크인 경과", "체크인 날짜 도래"),
+
+	// 취소 요청
+	CUSTOMER_CANCEL("사용자 취소 요청", "결제 전 사용자 취소"),
+	ADMIN_CANCEL("관리자 취소 요청", "결제 전 관리자 취소"),
+	HOST_REJECT("호스트 거절", "결제 전 호스트 거절"),
+
+	// 결제 취소 요청
+	CUSTOMER_PAYMENT_CANCEL("사용자 결제 취소 요청", "결제 후 사용자 취소"),
+	ADMIN_PAYMENT_CANCEL("관리자 결제 취소 요청", "결제 후 관리자 취소"),
+	HOST_PAYMENT_CANCEL("호스트 결제 취소 요청", "결제 후 호스트 거절"),
+
+	PG_PAID_CANCEL("PG 결제 취소 요청", "PG사 결제 취소 요청"),
+
+	// PG 실패
+	PG_CANCEL_FAIL("PG 취소 실패", "결제 취소 요청 실패");
+
+	private final String name;
+	private final String description;
+
+	ReservationEvents(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
+}

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -1,8 +1,33 @@
 package com.reservation.domain.reservation.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum ReservationStatus {
-	PENDING,     // 결제 대기 중
-	CONFIRMED,   // 결제 완료 및 예약 확정
-	CANCELED,    // 사용자 취소 or 결제 실패
-	EXPIRED      // 결제 시간 초과로 자동 무효
+	PENDING("결제 대기", "결제 대기 중"),
+	PAID("결제 완료", "결제 및 검증 완료"),
+	CONFIRMED("확정", "예약 확정"),
+
+	EXPIRED("결제 시간 초과", "결제 시간 초과로 자동 무효"),
+	PAID_ERROR("결제 에러", "미결제 혹은 결제 금액 불일치"),
+
+	CUSTOMER_CANCELED("사용자 취소", "사용자 취소"),
+	ADMIN_CANCELED("관리자 취소", "관리자 취소"),
+	HOST_REJECTED("호스트 거절", "호스트 거절"),
+
+	PAID_ERROR_CANCELED("결제 취소", "결제 에러로 인한 결제 취소"),
+	CUSTOMER_PAID_CANCELED("결제 취소", "사용자 취소로 인한 결제 취소"),
+	ADMIN_PAID_CANCELED("결제 취소", "관리자 취소로 인한 결제 취소"),
+	HOST_PAID_CANCELED("결제 취소", "업체 거절로 인한 결제 취소"),
+
+	PG_VALIDATE_ERROR("PG 검증 실패", "PG사 결제 검증 요청 실패"),
+	PG_CANCEL_FAIL("PG 결제 취소 실패", "PG사 결제 취소 요청 실패");
+
+	private final String name;
+	private final String description;
+
+	ReservationStatus(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
 }

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -4,11 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum ReservationStatus {
-	PENDING("결제 대기", "결제 대기 중"),
 	PAID("결제 완료", "결제 및 검증 완료"),
 	CONFIRMED("확정", "예약 확정"),
 
-	EXPIRED("결제 시간 초과", "결제 시간 초과로 자동 무효"),
 	PAID_ERROR("결제 에러", "미결제 혹은 결제 금액 불일치"),
 
 	CANCELED("예약 취소", "취소 요청으로 인한 취소 상태"),

--- a/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservation/enums/ReservationStatus.java
@@ -11,14 +11,10 @@ public enum ReservationStatus {
 	EXPIRED("결제 시간 초과", "결제 시간 초과로 자동 무효"),
 	PAID_ERROR("결제 에러", "미결제 혹은 결제 금액 불일치"),
 
-	CUSTOMER_CANCELED("사용자 취소", "사용자 취소"),
-	ADMIN_CANCELED("관리자 취소", "관리자 취소"),
-	HOST_REJECTED("호스트 거절", "호스트 거절"),
+	CANCELED("예약 취소", "취소 요청으로 인한 취소 상태"),
 
-	PAID_ERROR_CANCELED("결제 취소", "결제 에러로 인한 결제 취소"),
-	CUSTOMER_PAID_CANCELED("결제 취소", "사용자 취소로 인한 결제 취소"),
-	ADMIN_PAID_CANCELED("결제 취소", "관리자 취소로 인한 결제 취소"),
-	HOST_PAID_CANCELED("결제 취소", "업체 거절로 인한 결제 취소"),
+	PAID_ERROR_CANCELED("결제 취소", "결제 에러로 인한 결제 취소 상태"),
+	PAID_CANCELED("결제 취소", "결제 취소 상태"),
 
 	PG_VALIDATE_ERROR("PG 검증 실패", "PG사 결제 검증 요청 실패"),
 	PG_CANCEL_FAIL("PG 결제 취소 실패", "PG사 결제 취소 요청 실패");

--- a/core/domain/src/main/java/com/reservation/domain/reservationstatushistory/ReservationStatusHistory.java
+++ b/core/domain/src/main/java/com/reservation/domain/reservationstatushistory/ReservationStatusHistory.java
@@ -1,0 +1,40 @@
+package com.reservation.domain.reservationstatushistory;
+
+import java.time.LocalDateTime;
+
+import com.reservation.domain.base.BaseEntity;
+import com.reservation.domain.reservation.enums.ReservationStatus;
+
+import jakarta.persistence.Entity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ReservationStatusHistory extends BaseEntity {
+	private Long reservationId;
+	private ReservationStatus fromStatus;
+	private ReservationStatus toStatus;
+	private LocalDateTime transitionedAt;
+
+	@Builder
+	public ReservationStatusHistory(
+		long reservationId,
+		ReservationStatus fromStatus,
+		ReservationStatus toStatus
+	) {
+		if (reservationId <= 0) {
+			throw new IllegalArgumentException("reservationId는 필수입니다.");
+		}
+		if (fromStatus == null || toStatus == null) {
+			throw new IllegalArgumentException("fromStatus와 toStatus는 필수입니다.");
+		}
+
+		this.reservationId = reservationId;
+		this.fromStatus = fromStatus;
+		this.toStatus = toStatus;
+		this.transitionedAt = LocalDateTime.now();
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #104 

### 작업 내용

- ReservationController에 @PatchMapping("/reservations/{id}/cancel") 추가
- ReservationService에 cancelReservation() 메서드 구현
- 상태머신 전이 이벤트: CUSTOMER_PAYMENT_CANCEL → PG_PAID_CANCEL
- 결제 정보 조회 및 아임포트 취소 처리
- 예약 수량 복구 시 Redisson 락 적용 (roomTypeId + checkIn 기준)

## 스크린샷(선택)