### PR TITLE
[ identity-service ] 기본 회원 가입 API 추가 및 tsid 사용

### DIFF
--- a/identity-service/build.gradle.kts
+++ b/identity-service/build.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testImplementation("com.h2database:h2")
 	testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
 	testImplementation("io.kotest:kotest-assertions-core:5.9.1")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/identity-service/build.gradle.kts
+++ b/identity-service/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-jooq")
+	implementation("org.springframework.boot:spring-boot-starter-security")
 
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -32,11 +33,17 @@ dependencies {
 	implementation("org.flywaydb:flyway-core")
 	implementation("org.flywaydb:flyway-mysql")
 
+	implementation("com.github.f4b6a3:tsid-creator:5.2.6")
+
 	runtimeOnly("com.mysql:mysql-connector-j")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+	testImplementation("com.h2database:h2")
+	testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+	testImplementation("io.kotest:kotest-assertions-core:5.9.1")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
 
 	jooqGenerator("com.mysql:mysql-connector-j")
 }
@@ -90,6 +97,7 @@ jooq { // jOOQ 코드 생성 설정
 						isPojos = true // POJO 클래스 생성
 						isFluentSetters = true // Fluent Setter 생성
 						isJavaTimeTypes = true // 날짜/시간 타입을 Java 8+ Time API로 매핑
+						isKotlinNotNullPojoAttributes = true // Kotlin POJO에서 NotNull 속성을 non-nullable 타입으로 생성
 					}
 				}
 			}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/config/SecurityConfig.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/config/SecurityConfig.kt
@@ -1,0 +1,29 @@
+package com.msa.identityservice.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class SecurityConfig {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http.csrf { it.disable() }
+            .authorizeHttpRequests {
+                it.requestMatchers(HttpMethod.POST, "/members").permitAll()
+                    .anyRequest().authenticated()
+            }
+
+        return http.build()
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/infrastructure/IdGenerator.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/infrastructure/IdGenerator.kt
@@ -1,0 +1,12 @@
+package com.msa.identityservice.infrastructure
+
+import com.github.f4b6a3.tsid.TsidCreator
+import org.springframework.stereotype.Component
+
+@Component
+class IdGenerator {
+
+    fun generate(): Long {
+        return TsidCreator.getTsid().toLong()
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/MemberController.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/MemberController.kt
@@ -1,0 +1,29 @@
+package com.msa.identityservice.member.controller
+
+import com.msa.identityservice.member.controller.request.MemberRegistrationRequest
+import com.msa.identityservice.member.controller.response.MemberRegistrationResponse
+import com.msa.identityservice.member.service.MemberService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/members")
+class MemberController(
+    private val memberService: MemberService
+) {
+    @PostMapping()
+    fun register(@RequestBody request: MemberRegistrationRequest): ResponseEntity<MemberRegistrationResponse> {
+        val registerMemberDto = request.validateToRegisterMemberDto()
+        val newMember = memberService.register(registerMemberDto)
+        val response = MemberRegistrationResponse(
+            id = newMember.id,
+            email = newMember.email
+        )
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
@@ -1,0 +1,32 @@
+package com.msa.identityservice.member.controller.request
+
+import com.msa.identityservice.member.service.dto.RegisterMemberDto
+
+data class MemberRegistrationRequest(
+    val email: String,
+    val password: String,
+    val phoneNumber: String
+) {
+    fun validateToRegisterMemberDto(): RegisterMemberDto {
+        require(email.matches(EMAIL_REGEX)) { "올바른 이메일 형식이 아닙니다." }
+        require(password.matches(PASSWORD_REGEX)) { "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다." }
+        require(phoneNumber.matches(PHONE_NUMBER_REGEX)) { "올바른 휴대폰 번호 형식이 아닙니다. (010-XXXX-XXXX)" }
+
+        return RegisterMemberDto(
+            email = this.email,
+            password = this.password,
+            phoneNumber = this.phoneNumber
+        )
+    }
+
+    companion object {
+        // 이메일 형식 검증 정규식
+        private val EMAIL_REGEX = Regex("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+
+        // 비밀번호 정책 검증 정규식 (최소 8자, 영문, 숫자, 특수문자 각 1개 이상 포함)
+        private val PASSWORD_REGEX = Regex("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")
+
+        // 대한민국 휴대폰 번호 형식 검증 정규식 (010-XXXX-XXXX)
+        private val PHONE_NUMBER_REGEX = Regex("^010-\\d{4}-\\d{4}$")
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/response/MemberRegistrationResponse.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/response/MemberRegistrationResponse.kt
@@ -1,0 +1,6 @@
+package com.msa.identityservice.member.controller.response
+
+data class MemberRegistrationResponse(
+    val id: Long,
+    val email: String
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/repository/MemberRepository.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/repository/MemberRepository.kt
@@ -1,0 +1,34 @@
+package com.msa.identityservice.member.repository
+
+import com.msa.identityservice.jooq.enums.MemberStatus
+import com.msa.identityservice.jooq.tables.pojos.Member
+import com.msa.identityservice.jooq.tables.references.MEMBER
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberRepository(
+    private val dsl: DSLContext
+) {
+    fun save(member: Member) {
+        dsl.insertInto(MEMBER)
+            .set(MEMBER.ID, member.id)
+            .set(MEMBER.EMAIL, member.email)
+            .set(MEMBER.PASSWORD, member.password)
+            .set(MEMBER.PHONE_NUMBER, member.phoneNumber)
+            .set(MEMBER.STATUS, member.status)
+            .execute()
+    }
+
+    fun findActiveMemberByEmail(email: String): Member? {
+        return dsl.selectFrom(MEMBER)
+            .where(MEMBER.EMAIL.eq(email).and(MEMBER.STATUS.eq(MemberStatus.ACTIVE)))
+            .fetchOneInto(Member::class.java)
+    }
+
+    fun findById(id: Long): Member? {
+        return dsl.selectFrom(MEMBER)
+            .where(MEMBER.ID.eq(id))
+            .fetchOneInto(Member::class.java)
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/repository/MemberRepository.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/repository/MemberRepository.kt
@@ -20,15 +20,15 @@ class MemberRepository(
             .execute()
     }
 
-    fun findActiveMemberByEmail(email: String): Member? {
-        return dsl.selectFrom(MEMBER)
-            .where(MEMBER.EMAIL.eq(email).and(MEMBER.STATUS.eq(MemberStatus.ACTIVE)))
-            .fetchOneInto(Member::class.java)
-    }
-
     fun findById(id: Long): Member? {
         return dsl.selectFrom(MEMBER)
             .where(MEMBER.ID.eq(id))
+            .fetchOneInto(Member::class.java)
+    }
+
+    fun findActiveMemberByEmail(email: String): Member? {
+        return dsl.selectFrom(MEMBER)
+            .where(MEMBER.EMAIL.eq(email).and(MEMBER.STATUS.eq(MemberStatus.ACTIVE)))
             .fetchOneInto(Member::class.java)
     }
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/service/MemberService.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/service/MemberService.kt
@@ -1,0 +1,34 @@
+package com.msa.identityservice.member.service
+
+import com.msa.identityservice.infrastructure.IdGenerator
+import com.msa.identityservice.jooq.tables.pojos.Member
+import com.msa.identityservice.member.repository.MemberRepository
+import com.msa.identityservice.member.service.dto.RegisterMemberDto
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository,
+    private val idGenerator: IdGenerator,
+    private val passwordEncoder: PasswordEncoder
+) {
+    fun register(registerMemberDto: RegisterMemberDto): Member {
+        checkEmailDuplicateThrow(registerMemberDto.email)
+
+        val newMember = registerMemberDto.toNewMember(
+            newId = idGenerator.generate(),
+            encoderPassword = passwordEncoder.encode(registerMemberDto.password)
+        )
+
+        memberRepository.save(newMember)
+
+        return newMember
+    }
+
+    fun checkEmailDuplicateThrow(email: String) {
+        memberRepository.findActiveMemberByEmail(email)?.let {
+            throw IllegalStateException("이미 사용 중인 이메일입니다.")
+        }
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/service/dto/RegisterMemberDto.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/service/dto/RegisterMemberDto.kt
@@ -1,0 +1,21 @@
+package com.msa.identityservice.member.service.dto
+
+import com.msa.identityservice.jooq.enums.MemberStatus
+import com.msa.identityservice.jooq.tables.pojos.Member
+
+
+data class RegisterMemberDto(
+    val email: String,
+    val password: String,
+    val phoneNumber: String
+) {
+    fun toNewMember(newId: Long, encoderPassword: String): Member {
+        return Member(
+            id = newId,
+            email = email,
+            password = encoderPassword,
+            phoneNumber = phoneNumber,
+            status = MemberStatus.ACTIVE
+        )
+    }
+}

--- a/identity-service/src/main/resources/db/migration/V1__Create_member_table.sql
+++ b/identity-service/src/main/resources/db/migration/V1__Create_member_table.sql
@@ -1,7 +1,15 @@
 -- V1__Create_member_table.sql
+
 CREATE TABLE `member` (
-    `id` VARCHAR(100) NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `created_at` DATETIME NOT NULL,
-    PRIMARY KEY (`id`)
+    -- Snowflake ID는 64비트 정수이므로 BIGINT로 설정
+    `id` BIGINT NOT NULL,
+    `email` VARCHAR(255) NOT NULL COMMENT '로그인 이메일',
+    `password` VARCHAR(255) NOT NULL COMMENT '해싱된 비밀번호',
+    `phone_number` VARCHAR(20) NULL COMMENT '휴대폰 번호',
+    `status` ENUM('ACTIVE', 'DELETED') NOT NULL DEFAULT 'ACTIVE',
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    -- email을 이용한 조회가 많으므로 UNIQUE INDEX 추가
+    UNIQUE INDEX `uk_member_email` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/identity-service/src/test/kotlin/com/msa/identityservice/config/JooqTestConfig.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/config/JooqTestConfig.kt
@@ -1,0 +1,26 @@
+package com.msa.identityservice.config
+
+import org.jooq.conf.RenderMapping
+import org.jooq.conf.MappedSchema
+import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JooqTestConfig {
+
+    @Bean
+    fun jooqTestConfigurationCustomizer(): DefaultConfigurationCustomizer {
+        return DefaultConfigurationCustomizer { config ->
+            config.settings()
+                .withRenderMapping(
+                    RenderMapping().withSchemata(
+                        // 입력 스키마(코드에 하드코딩된 값)가 "identity-db"일 경우,
+                        MappedSchema().withInput("identity-db")
+                                     // 출력 스키마(실제 쿼리에 나갈 값)를 "identity-test-db"로 변경합니다.
+                                     .withOutput("identity-test-db")
+                    )
+                )
+        }
+    }
+}

--- a/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
@@ -1,0 +1,54 @@
+package com.msa.identityservice.member
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.msa.identityservice.jooq.enums.MemberStatus
+import com.msa.identityservice.member.controller.request.MemberRegistrationRequest
+import com.msa.identityservice.member.repository.MemberRepository
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@AutoConfigureMockMvc // MockMvc를 실제 서버처럼 사용하기 위한 설정
+@Transactional
+class MemberControllerIntegrationTest @Autowired constructor(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+    private val memberRepository: MemberRepository, // DB 상태 검증을 위해 실제 Repository 주입
+    private val passwordEncoder: PasswordEncoder
+) {
+
+    @Test
+    fun `회원 가입에 성공하고, 데이터베이스에 암호화된 비밀번호로 저장된다`() {
+        // Given
+        val request = MemberRegistrationRequest("test@example.com", "password123", "010-1234-5678")
+
+        // When
+        val result = mockMvc.post("/members") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isCreated() } // 201 Created 상태인지 확인
+            jsonPath("$.email") { value(request.email) }
+        }.andReturn()
+
+        // Then: DB에서 직접 데이터를 조회하여 검증
+        val responseBody = objectMapper.readTree(result.response.contentAsString)
+        val memberId = responseBody.get("id").asLong()
+        val savedMember = memberRepository.findById(memberId)
+
+        savedMember shouldNotBe null
+        savedMember?.email shouldBe request.email
+        savedMember?.phoneNumber shouldBe request.phoneNumber
+        savedMember?.status shouldBe MemberStatus.ACTIVE
+        passwordEncoder.matches(request.password, savedMember?.password) shouldBe true // 비밀번호가 암호화되었는지 확인
+    }
+}

--- a/identity-service/src/test/resources/application.yml
+++ b/identity-service/src/test/resources/application.yml
@@ -1,19 +1,17 @@
-server:
-  port: ${SERVER_PORT:8081}
-
 spring:
   application:
     name: identity-service
   datasource:
-    url: ${DB_URL:jdbc:mysql://localhost:30306/identity-db}
-    username: ${DB_USER:root}
-    password: ${DB_PASSWORD:root}
+    url: ${TEST_DB_URL:jdbc:mysql://localhost:30306/identity-test-db}
+    username: ${TEST_DB_USER:root}
+    password: ${TEST_DB_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jooq:
     sql-dialect: MYSQL
   flyway:
     enabled: true
     baseline-on-migrate: true # 기존에 테이블이 있는 DB에 처음 적용할 때, 현재 상태를 기준으로 삼는 설정
+    schemas: identity-test-db
 
 logging:
   level:


### PR DESCRIPTION
## 📝 Description

`identity-service`에 **회원 가입 API 엔드포인트를 추가**합니다.

사용자는 이메일, 비밀번호, 휴대폰 번호를 통해 가입할 수 있으며, 요청 데이터에 대한 정교한 유효성 검사, 비밀번호 암호화, 데이터베이스 저장 및 테스트 코드까지 전체 기능 흐름을 구현했습니다.

## ✨ Changes

- **API Layer (`/member/controller`)**
    - `POST /members` 엔드포인트를 담당하는 `MemberController`를 추가했습니다.
    - 요청/응답 데이터 구조를 정의하는 `MemberRegistrationRequest/Response` DTO를 구현했습니다.
    - DTO 내부에 정규 표현식을 사용한 함수 기반 유효성 검사 로직을 추가했습니다.

- **Service Layer (`/member/service`)**
    - 회원 가입 비즈니스 로직을 처리하는 `MemberService`를 구현했습니다.
    - 이메일 중복 체크, `BCryptPasswordEncoder`를 사용한 비밀번호 암호화 로직이 포함됩니다.

- **Repository Layer (`/member/repository`)**
    - jOOQ를 사용하여 `member` 테이블에 데이터를 저장하고 조회하는 `MemberRepository`를 구현했습니다.

- **Infrastructure & Config**
    - 분산 환경에 적합한 Snowflake ID를 생성하는 `IdGenerator`를 추가했습니다.

- **Testing**
    - **`MemberControllerIntegrationTest`**: `@SpringBootTest`와 `MockMvc`를 사용하여 API 요청부터 DB 저장까지 전체 흐름을 검증합니다.

## ✅ How to Test

1.  `./gradlew clean test` 명령어로 모든 자동화 테스트가 통과하는지 확인합니다.
2.  애플리케이션 실행 후, Postman 등을 통해 `POST /members` API에 유효한 데이터를 전송하여 `201 Created` 응답이 오는지 확인합니다.