### PR TITLE
[ identity-service ] 예외 코드, Global Exception Handler 구성 및 응답 구조 통일

### DIFF
--- a/identity-service/build.gradle.kts
+++ b/identity-service/build.gradle.kts
@@ -24,11 +24,13 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-jooq")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("io.github.oshai:kotlin-logging-jvm:7.0.11")
 
 	implementation("org.flywaydb:flyway-core")
 	implementation("org.flywaydb:flyway-mysql")

--- a/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessErrorCode.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessErrorCode.kt
@@ -1,0 +1,26 @@
+package com.msa.identityservice.exception
+
+import org.springframework.http.HttpStatus
+
+
+enum class BusinessErrorCode(private val httpStatus: HttpStatus, private val defaultMessage: String) {
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했거나, 요청 값이 잘못되었습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했거나, 요청 값이 잘못되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나, 인증에 실패했습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, "이미 존재하거나, 처리된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+
+    fun httpStatus(): HttpStatus {
+        return httpStatus
+    }
+
+    fun defaultMessage(): String {
+        return defaultMessage
+    }
+
+    fun exception(message: String?): BusinessException {
+        return BusinessException(this, message ?: this.defaultMessage)
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessException.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessException.kt
@@ -1,0 +1,18 @@
+package com.msa.identityservice.exception
+
+import org.springframework.http.HttpStatus
+
+
+class BusinessException (
+    private val errorCode: BusinessErrorCode,
+    override val message: String
+) : RuntimeException(message) {
+
+    fun errorCode(): BusinessErrorCode {
+        return errorCode
+    }
+
+    fun httpStatus(): HttpStatus {
+        return errorCode.httpStatus()
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/exception/GlobalExceptionHandler.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,72 @@
+package com.msa.identityservice.exception
+
+import com.msa.identityservice.support.response.ApiResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
+import java.util.stream.Collectors
+
+
+private val logger = KotlinLogging.logger {}
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(NoHandlerFoundException::class)
+    fun handleNotFound(noHandlerFoundException: NoHandlerFoundException): ResponseEntity<ApiResponse<Nothing>> {
+        logger.error { noHandlerFoundException }
+        val response = ApiResponse.error(BusinessErrorCode.NOT_FOUND.name, NOT_FOUND_ERROR_MESSAGE)
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(methodArgumentNotValidException: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
+        val fieldErrors = methodArgumentNotValidException.bindingResult.fieldErrors
+        val message = fieldErrors.stream()
+            .map { error: FieldError -> String.format("[%s] %s", error.field, error.defaultMessage) }
+            .collect(Collectors.joining(" | "))
+
+        val response = ApiResponse.error(BusinessErrorCode.VALIDATION_ERROR.name, message)
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
+    }
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<ApiResponse<Nothing>> {
+        val message = e.constraintViolations.joinToString(" | ") {
+            // ConstraintViolation에서 필드명과 메시지를 추출합니다.
+            val propertyPath = it.propertyPath.toString()
+            val fieldName = propertyPath.substring(propertyPath.lastIndexOf('.') + 1)
+            "[$fieldName] ${it.message}"
+        }
+
+        val response = ApiResponse.error(BusinessErrorCode.VALIDATION_ERROR.name, message)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(businessException: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
+        val status: HttpStatus = businessException.errorCode().httpStatus()
+        val responseCode = businessException.errorCode().name
+        val response = ApiResponse.error(responseCode, businessException.message)
+
+        return ResponseEntity.status(status).body(response)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpectedException(exception: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        logger.error { exception }
+        val response = ApiResponse.error(BusinessErrorCode.INTERNAL_SERVER_ERROR.name, DEFAULT_ERROR_MESSAGE)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response)
+    }
+
+    companion object {
+        private const val NOT_FOUND_ERROR_MESSAGE = "존재하지 않는 URL입니다"
+        private const val DEFAULT_ERROR_MESSAGE = "서버 내부 오류로 인한 작업 실패"
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/MemberController.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/MemberController.kt
@@ -3,11 +3,13 @@ package com.msa.identityservice.member.controller
 import com.msa.identityservice.member.controller.request.MemberRegistrationRequest
 import com.msa.identityservice.member.controller.response.MemberRegistrationResponse
 import com.msa.identityservice.member.service.MemberService
+import com.msa.identityservice.support.response.ApiResponse
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,14 +18,12 @@ class MemberController(
     private val memberService: MemberService
 ) {
     @PostMapping()
-    fun register(@RequestBody request: MemberRegistrationRequest): ResponseEntity<MemberRegistrationResponse> {
-        val registerMemberDto = request.validateToRegisterMemberDto()
+    @ResponseStatus(HttpStatus.CREATED)
+    fun register(@Valid @RequestBody request: MemberRegistrationRequest): ApiResponse<MemberRegistrationResponse> {
+        val registerMemberDto = request.toRegisterMemberDto()
         val newMember = memberService.register(registerMemberDto)
-        val response = MemberRegistrationResponse(
-            id = newMember.id,
-            email = newMember.email
-        )
+        val response = MemberRegistrationResponse(id = newMember.id, email = newMember.email)
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+        return ApiResponse.create(message = "회원 가입에 성공했습니다.", response)
     }
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
@@ -11,7 +11,7 @@ data class MemberRegistrationRequest(
     val email: String,
 
     @field:NotBlank(message = "비밀번호는 필수입니다.")
-    @field:Pattern(regexp = PASSWORD_PATTERN,message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
+    @field:Pattern(regexp = PW_PATTERN,message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
     val password: String,
 
     @field:NotBlank(message = "휴대폰 번호는 필수입니다.")
@@ -28,7 +28,7 @@ data class MemberRegistrationRequest(
 
     companion object {
         // 비밀번호 정책 검증 정규식 (최소 8자, 영문, 숫자, 특수문자 각 1개 이상 포함)
-        private const val PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$"
+        private const val PW_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$"
 
         // 대한민국 휴대폰 번호 형식 검증 정규식 (010-XXXX-XXXX)
         private const val PHONE_NUMBER_PATTERN = "^010-\\d{4}-\\d{4}$"

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
@@ -1,17 +1,24 @@
 package com.msa.identityservice.member.controller.request
 
 import com.msa.identityservice.member.service.dto.RegisterMemberDto
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 
 data class MemberRegistrationRequest(
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
     val email: String,
+
+    @field:NotBlank(message = "비밀번호는 필수입니다.")
+    @field:Pattern(regexp = PASSWORD_PATTERN,message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
     val password: String,
+
+    @field:NotBlank(message = "휴대폰 번호는 필수입니다.")
+    @field:Pattern(regexp = PHONE_NUMBER_PATTERN, message = "올바른 휴대폰 번호 형식이 아닙니다. (010-XXXX-XXXX)")
     val phoneNumber: String
 ) {
-    fun validateToRegisterMemberDto(): RegisterMemberDto {
-        require(email.matches(EMAIL_REGEX)) { "올바른 이메일 형식이 아닙니다." }
-        require(password.matches(PASSWORD_REGEX)) { "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다." }
-        require(phoneNumber.matches(PHONE_NUMBER_REGEX)) { "올바른 휴대폰 번호 형식이 아닙니다. (010-XXXX-XXXX)" }
-
+    fun toRegisterMemberDto(): RegisterMemberDto {
         return RegisterMemberDto(
             email = this.email,
             password = this.password,
@@ -20,13 +27,10 @@ data class MemberRegistrationRequest(
     }
 
     companion object {
-        // 이메일 형식 검증 정규식
-        private val EMAIL_REGEX = Regex("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
-
         // 비밀번호 정책 검증 정규식 (최소 8자, 영문, 숫자, 특수문자 각 1개 이상 포함)
-        private val PASSWORD_REGEX = Regex("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")
+        private const val PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$"
 
         // 대한민국 휴대폰 번호 형식 검증 정규식 (010-XXXX-XXXX)
-        private val PHONE_NUMBER_REGEX = Regex("^010-\\d{4}-\\d{4}$")
+        private const val PHONE_NUMBER_PATTERN = "^010-\\d{4}-\\d{4}$"
     }
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/service/MemberService.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/service/MemberService.kt
@@ -1,5 +1,6 @@
 package com.msa.identityservice.member.service
 
+import com.msa.identityservice.exception.BusinessErrorCode
 import com.msa.identityservice.infrastructure.IdGenerator
 import com.msa.identityservice.jooq.tables.pojos.Member
 import com.msa.identityservice.member.repository.MemberRepository
@@ -28,7 +29,7 @@ class MemberService(
 
     fun checkEmailDuplicateThrow(email: String) {
         memberRepository.findActiveMemberByEmail(email)?.let {
-            throw IllegalStateException("이미 사용 중인 이메일입니다.")
+            throw BusinessErrorCode.CONFLICT.exception("이미 사용 중인 이메일입니다.")
         }
     }
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/support/response/ApiResponse.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/support/response/ApiResponse.kt
@@ -1,0 +1,30 @@
+package com.msa.identityservice.support.response
+
+data class ApiResponse<T>(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: T?
+) {
+    companion object {
+        fun <T> create(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "create", message, data)
+        }
+
+        fun <T> read(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "read", message, data)
+        }
+
+        fun <T> update(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "update", message, data)
+        }
+
+        fun noContent(message: String): ApiResponse<Nothing> {
+            return ApiResponse(true, "noContent", message, null)
+        }
+
+        fun error(code: String, message: String): ApiResponse<Nothing> {
+            return ApiResponse( false, code, message, null)
+        }
+    }
+}

--- a/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
@@ -1,7 +1,9 @@
 package com.msa.identityservice.member
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.msa.identityservice.exception.BusinessErrorCode
 import com.msa.identityservice.jooq.enums.MemberStatus
+import com.msa.identityservice.jooq.tables.pojos.Member
 import com.msa.identityservice.member.controller.request.MemberRegistrationRequest
 import com.msa.identityservice.member.repository.MemberRepository
 import io.kotest.matchers.shouldBe
@@ -29,7 +31,11 @@ class MemberControllerIntegrationTest @Autowired constructor(
     @Test
     fun `회원 가입에 성공하고, 데이터베이스에 암호화된 비밀번호로 저장된다`() {
         // Given
-        val request = MemberRegistrationRequest("test@example.com", "password123", "010-1234-5678")
+        val request = MemberRegistrationRequest(
+            email = "test@example.com",
+            password = "Password123!",
+            phoneNumber = "010-1234-5678"
+        )
 
         // When
         val result = mockMvc.post("/members") {
@@ -37,12 +43,15 @@ class MemberControllerIntegrationTest @Autowired constructor(
             content = objectMapper.writeValueAsString(request)
         }.andExpect {
             status { isCreated() } // 201 Created 상태인지 확인
-            jsonPath("$.email") { value(request.email) }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.code") { value("create") }
+            jsonPath("$.data.email") { value(request.email) }
+
         }.andReturn()
 
         // Then: DB에서 직접 데이터를 조회하여 검증
         val responseBody = objectMapper.readTree(result.response.contentAsString)
-        val memberId = responseBody.get("id").asLong()
+        val memberId = responseBody.get("data").get("id").asLong()
         val savedMember = memberRepository.findById(memberId)
 
         savedMember shouldNotBe null
@@ -50,5 +59,33 @@ class MemberControllerIntegrationTest @Autowired constructor(
         savedMember?.phoneNumber shouldBe request.phoneNumber
         savedMember?.status shouldBe MemberStatus.ACTIVE
         passwordEncoder.matches(request.password, savedMember?.password) shouldBe true // 비밀번호가 암호화되었는지 확인
+    }
+
+    @Test
+    fun `이미 존재하는 이메일로 가입을 시도하면 409 Conflict와 에러 응답을 반환한다`() {
+        // Given: 먼저 사용자를 하나 저장해 둠
+        val existingEmail = "test@example.com"
+        val existingMember = Member(
+            id = 1L,
+            email = existingEmail,
+            password = "password",
+            phoneNumber = "010-1234-5678",
+            status = MemberStatus.ACTIVE,
+        )
+        memberRepository.save(existingMember)
+
+        val request = MemberRegistrationRequest(existingEmail, "Password123!", "010-1111-2222")
+
+        // When & Then
+        mockMvc.post("/members") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isConflict() } // 409 Conflict 상태인지 확인
+            // ApiResponse 에러 형식 검증
+            jsonPath("$.success") { value(false) }
+            jsonPath("$.code") { value(BusinessErrorCode.CONFLICT.name) }
+            jsonPath("$.message") { value("이미 사용 중인 이메일입니다.") }
+        }
     }
 }


### PR DESCRIPTION
## 📝 Description

서비스 전반에서 사용될 **표준화된 예외 처리 및 API 응답 구조를 설계**했습니다.

## ✨ Changes
### 공통 에러 핸들링 및 응답 구조 설계
- **Standardized Response**: 모든 API 응답을 `ApiResponse<T>` 래퍼 클래스로 감싸 일관된 응답 형식을 제공합니다. (`success`, `code`, `message`, `data`)
- **Custom Exceptions**: `BusinessErrorCode` enum과 `BusinessException`을 정의하여, 예측 가능한 비즈니스 예외를 체계적으로 관리합니다.
- **Global Exception Handling**: `@RestControllerAdvice` (`GlobalExceptionHandler`)를 사용하여 아래 예외들을 공통으로 처리하고, 표준화된 에러 응"답을 반환합니다.
    - `BusinessException` (커스텀 비즈니스 예외)
    - `MethodArgumentNotValidException` (`@Valid` 애노테이션 검증 실패)
    - `ConstraintViolationException` (`@Validated` 애노테이션 검증 실패)
    - 그 외 예측하지 못한 `Exception`

## ✅ How to Test

1.  `./gradlew clean test` 명령어로 모든 자동화 테스트가 통과하는지 확인합니다.
2.  Postman 등을 통해 `POST /members` API에 아래 케이스들을 테스트합니다.
    - **성공**: 유효한 데이터로 요청 시 `201 Created` 및 `ApiResponse` 반환 확인
    - **실패**: 잘못된 형식의 데이터(이메일, 비밀번호 등)로 요청 시 `400 Bad Request` 및 `ApiResponse` 에러 반환 확인
    - **중복**: 이미 가입된 이메일로 요청 시 `409 Conflict` 및 `ApiResponse` 에러 반환 확인