### PR TITLE
[ identity-service ] Login, 토큰 재발급, 내 정보 확인 API 등 기본 인증 설계

### DIFF
--- a/identity-service/build.gradle.kts
+++ b/identity-service/build.gradle.kts
@@ -1,11 +1,11 @@
 import org.jooq.meta.jaxb.ForcedType
 
 plugins {
-	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.5.5"
-	id("io.spring.dependency-management") version "1.1.7"
-	id("nu.studer.jooq") version "9.0" // jOOQ 코드 생성을 위한 플러그인
+    kotlin("jvm") version "1.9.25"
+    kotlin("plugin.spring") version "1.9.25"
+    id("org.springframework.boot") version "3.5.5"
+    id("io.spring.dependency-management") version "1.1.7"
+    id("nu.studer.jooq") version "9.0" // jOOQ 코드 생성을 위한 플러그인
 }
 
 group = "com.msa"
@@ -13,40 +13,47 @@ version = "0.0.1-SNAPSHOT"
 description = "identity-service"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
+val jjwtVersion = "0.12.6"
+val kotestVersion = "5.9.1"
+
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("org.springframework.boot:spring-boot-starter-validation")
-	implementation("org.springframework.boot:spring-boot-starter-jooq")
-	implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-jooq")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("io.github.oshai:kotlin-logging-jvm:7.0.11")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.github.oshai:kotlin-logging-jvm:7.0.11")
 
-	implementation("org.flywaydb:flyway-core")
-	implementation("org.flywaydb:flyway-mysql")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
 
-	implementation("com.github.f4b6a3:tsid-creator:5.2.6")
+    implementation("com.github.f4b6a3:tsid-creator:5.2.6")
 
-	runtimeOnly("com.mysql:mysql-connector-j")
+    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
 
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
-	testImplementation("io.kotest:kotest-assertions-core:5.9.1")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    runtimeOnly("com.mysql:mysql-connector-j")
 
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-	jooqGenerator("com.mysql:mysql-connector-j")
+    jooqGenerator("com.mysql:mysql-connector-j")
 }
 
 val dbUrl = project.findProperty("db.url") as? String ?: "jdbc:mysql://localhost:30306/identity-db"
@@ -54,66 +61,66 @@ val dbUser = project.findProperty("db.user") as? String ?: "root"
 val dbPassword = project.findProperty("db.password") as? String ?: "root"
 
 jooq { // jOOQ 코드 생성 설정
-	version.set(dependencyManagement.importedProperties["jooq.version"]) // SpringBoot 관리하는 jOOQ 버전을 사용
+    version.set(dependencyManagement.importedProperties["jooq.version"]) // SpringBoot 관리하는 jOOQ 버전을 사용
 
-	configurations {
-		create("main") {
-			generateSchemaSourceOnCompilation.set(true) // 코드 생성을 빌드 시 자동으로 실행하고 싶지 않다면 false 설정
+    configurations {
+        create("main") {
+            generateSchemaSourceOnCompilation.set(true) // 코드 생성을 빌드 시 자동으로 실행하고 싶지 않다면 false 설정
 
-			jooqConfiguration.apply {
-				jdbc.apply {
-					driver = "com.mysql.cj.jdbc.Driver"
-					url = dbUrl
-					user = dbUser
-					password = dbPassword
-				}
+            jooqConfiguration.apply {
+                jdbc.apply {
+                    driver = "com.mysql.cj.jdbc.Driver"
+                    url = dbUrl
+                    user = dbUser
+                    password = dbPassword
+                }
 
-				generator.apply {
-					name = "org.jooq.codegen.KotlinGenerator" // Java 대신 Kotlin 코드를 생성하도록 설정
+                generator.apply {
+                    name = "org.jooq.codegen.KotlinGenerator" // Java 대신 Kotlin 코드를 생성하도록 설정
 
-					database.apply {
-						name = "org.jooq.meta.mysql.MySQLDatabase"
-						inputSchema = "identity-db" // 생성할 스키마 지정
-						excludes = "flyway_schema_history|batch_.*" // 생성에서 제외할 테이블 (정규식 사용 가능)
+                    database.apply {
+                        name = "org.jooq.meta.mysql.MySQLDatabase"
+                        inputSchema = "identity-db" // 생성할 스키마 지정
+                        excludes = "flyway_schema_history|batch_.*" // 생성에서 제외할 테이블 (정규식 사용 가능)
 
-						// unsigned 타입을 강제로 Long으로 매핑
-						forcedTypes = listOf(
-							ForcedType()
-								.withUserType("java.lang.Long")
-								.withIncludeExpression(".*\\.UNSIGNED")
-								.withIncludeTypes("BIGINT")
-						)
-					}
+                        // unsigned 타입을 강제로 Long으로 매핑
+                        forcedTypes = listOf(
+                            ForcedType()
+                                .withUserType("java.lang.Long")
+                                .withIncludeExpression(".*\\.UNSIGNED")
+                                .withIncludeTypes("BIGINT")
+                        )
+                    }
 
-					target.apply {
-						// 생성될 코드의 패키지 경로
-						packageName = "com.msa.identityservice.jooq"
-						// 생성될 코드의 디렉토리 경로
-						directory = "src/main/generated"
-					}
+                    target.apply {
+                        // 생성될 코드의 패키지 경로
+                        packageName = "com.msa.identityservice.jooq"
+                        // 생성될 코드의 디렉토리 경로
+                        directory = "src/main/generated"
+                    }
 
-					generate.apply {
-						isRecords = true // Record 클래스 생성
-						isDaos = false // DAO 클래스는 생성하지 않음 (선택 사항)
-						isPojos = true // POJO 클래스 생성
-						isFluentSetters = true // Fluent Setter 생성
-						isJavaTimeTypes = true // 날짜/시간 타입을 Java 8+ Time API로 매핑
-						isKotlinNotNullPojoAttributes = true // Kotlin POJO에서 NotNull 속성을 non-nullable 타입으로 생성
-					}
-				}
-			}
-		}
-	}
+                    generate.apply {
+                        isRecords = true // Record 클래스 생성
+                        isDaos = false // DAO 클래스는 생성하지 않음 (선택 사항)
+                        isPojos = true // POJO 클래스 생성
+                        isFluentSetters = true // Fluent Setter 생성
+                        isJavaTimeTypes = true // 날짜/시간 타입을 Java 8+ Time API로 매핑
+                        isKotlinNotNullPojoAttributes = true // Kotlin POJO에서 NotNull 속성을 non-nullable 타입으로 생성
+                    }
+                }
+            }
+        }
+    }
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict")
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 sourceSets.main.get().java.srcDirs("src/main/generated")

--- a/identity-service/src/main/kotlin/com/msa/identityservice/IdentityServiceApplication.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/IdentityServiceApplication.kt
@@ -1,9 +1,11 @@
 package com.msa.identityservice
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan(basePackages = ["com.msa.identityservice.config.properties"])
 class IdentityServiceApplication
 
 fun main(args: Array<String>) {

--- a/identity-service/src/main/kotlin/com/msa/identityservice/annotation/LoginUser.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/annotation/LoginUser.kt
@@ -1,0 +1,5 @@
+package com.msa.identityservice.annotation
+
+@Target(AnnotationTarget.TYPE_PARAMETER, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LoginUser

--- a/identity-service/src/main/kotlin/com/msa/identityservice/annotation/LoginUserArgumentResolver.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/annotation/LoginUserArgumentResolver.kt
@@ -1,0 +1,59 @@
+package com.msa.identityservice.annotation
+
+import com.msa.identityservice.auth.service.AuthService.Companion.ACTIVE_KEY_PREFIX
+import com.msa.identityservice.auth.token.JwtTokenProvider
+import com.msa.identityservice.auth.token.RequestContext
+import com.msa.identityservice.auth.token.dto.TokenAuthInfo
+import com.msa.identityservice.auth.token.enums.Role
+import com.msa.identityservice.exception.BusinessErrorCode
+import org.springframework.core.MethodParameter
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+
+@Component
+class LoginUserArgumentResolver(
+    private val requestContext: RequestContext,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val redisTemplate: RedisTemplate<String, String>
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        val hasParameterAnnotation = parameter.hasParameterAnnotation(LoginUser::class.java)
+        val isTokenAuthInfo = parameter.parameterType == TokenAuthInfo::class.java
+
+        return hasParameterAnnotation && isTokenAuthInfo
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): TokenAuthInfo {
+        val accessToken = requestContext.getAccessToken()
+        val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
+
+        checkActiveToken(
+            role = tokenAuthInfo.role,
+            userId = tokenAuthInfo.userId,
+            deviceId = tokenAuthInfo.deviceId
+        )
+
+        return tokenAuthInfo
+    }
+
+    private fun checkActiveToken(
+        role: Role,
+        userId: Long,
+        deviceId: String
+    ) {
+        redisTemplate.opsForValue().get("$ACTIVE_KEY_PREFIX:${role.name.lowercase()}:$userId:$deviceId")
+            ?: throw BusinessErrorCode.UNAUTHORIZED.exception("로그아웃 처리 된 인증 정보입니다. 다시 로그인 해주세요.")
+    }
+
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/AuthController.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/AuthController.kt
@@ -1,0 +1,68 @@
+package com.msa.identityservice.auth.controller
+
+import com.msa.identityservice.annotation.LoginUser
+import com.msa.identityservice.auth.controller.request.LoginRequest
+import com.msa.identityservice.auth.service.AuthService
+import com.msa.identityservice.auth.token.dto.LoginAuthToken
+import com.msa.identityservice.auth.token.dto.TokenAuthInfo
+import com.msa.identityservice.support.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+
+    @PostMapping("/login")
+    fun login(
+        @Valid @RequestBody
+        request: LoginRequest
+    ): ResponseEntity<Void> {
+        val loginRequestInfo = request.toLoginRequestInfo()
+        val loginSettingToken = authService.login(loginRequestInfo)
+
+        return setTokenHeaders(loginSettingToken)
+    }
+
+    private fun setTokenHeaders(loginAuthToken: LoginAuthToken): ResponseEntity<Void> {
+        val (accessTokenHeader, refreshTokenCookie) = loginAuthToken
+        val responseCookie: ResponseCookie = ResponseCookie.from(refreshTokenCookie.name, refreshTokenCookie.value)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(refreshTokenCookie.refreshDuration)
+            .build()
+
+        return ResponseEntity.noContent()
+            .header(accessTokenHeader.name, accessTokenHeader.value)
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .header("Access-Control-Expose-Headers", accessTokenHeader.name)
+            .build()
+    }
+
+    @GetMapping("/refresh")
+    fun tokenReissue(): ResponseEntity<Void> {
+        val loginSettingToken = authService.tokenReissue()
+
+        return setTokenHeaders(loginSettingToken)
+    }
+
+    @GetMapping("/me")
+    fun getMe(
+        @LoginUser
+        tokenAuthInfo: TokenAuthInfo
+    ): ApiResponse<TokenAuthInfo> {
+
+        return ApiResponse.read(
+            message = "내 정보 조회에 성공했습니다.",
+            data = tokenAuthInfo
+        )
+    }
+
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/AuthController.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/AuthController.kt
@@ -23,14 +23,14 @@ class AuthController(
     fun login(
         @Valid @RequestBody
         request: LoginRequest
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val loginRequestInfo = request.toLoginRequestInfo()
         val loginSettingToken = authService.login(loginRequestInfo)
 
         return setTokenHeaders(loginSettingToken)
     }
 
-    private fun setTokenHeaders(loginAuthToken: LoginAuthToken): ResponseEntity<Void> {
+    private fun setTokenHeaders(loginAuthToken: LoginAuthToken): ResponseEntity<Unit> {
         val (accessTokenHeader, refreshTokenCookie) = loginAuthToken
         val responseCookie: ResponseCookie = ResponseCookie.from(refreshTokenCookie.name, refreshTokenCookie.value)
             .httpOnly(true)
@@ -47,7 +47,7 @@ class AuthController(
     }
 
     @GetMapping("/refresh")
-    fun tokenReissue(): ResponseEntity<Void> {
+    fun tokenReissue(): ResponseEntity<Unit> {
         val loginSettingToken = authService.tokenReissue()
 
         return setTokenHeaders(loginSettingToken)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/request/LoginRequest.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/request/LoginRequest.kt
@@ -1,0 +1,31 @@
+package com.msa.identityservice.auth.controller.request
+
+import com.msa.identityservice.auth.service.dto.LoginRequestInfo
+import com.msa.identityservice.auth.token.enums.Role
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+
+data class LoginRequest(
+    @field:Email(message = "이메일 형식이 올바르지 않습니다.")
+    @field:NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    val email: String?,
+
+    @field:NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    val password: String?,
+
+    @field:NotNull(message = "Role은 MEMBER, HOST, ADMIN 중 하나여야 합니다.")
+    val role: Role?,
+
+    @field:NotBlank(message = "로그인 기기 ID는 필수입니다.")
+    val deviceId: String? // TODO: Device Fingerprinting
+) {
+    fun toLoginRequestInfo() = LoginRequestInfo(
+        email = email!!,
+        password = password!!,
+        role = role!!,
+        deviceId = deviceId!!
+    )
+
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/request/LogoutRequest.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/controller/request/LogoutRequest.kt
@@ -1,0 +1,8 @@
+package com.msa.identityservice.auth.controller.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class LogoutRequest(
+    @field:NotBlank(message = "로그아웃 기기 ID는 필수입니다.")
+    val deviceId: String? // TODO: Device Fingerprinting
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/service/AuthService.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/service/AuthService.kt
@@ -1,0 +1,218 @@
+package com.msa.identityservice.auth.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.msa.identityservice.auth.service.dto.LoginRequestInfo
+import com.msa.identityservice.auth.token.JwtTokenProvider
+import com.msa.identityservice.auth.token.RequestContext
+import com.msa.identityservice.auth.token.dto.AccessTokenHeader
+import com.msa.identityservice.auth.token.dto.LoginAuthToken
+import com.msa.identityservice.auth.token.dto.RefreshTokenCookie
+import com.msa.identityservice.auth.token.dto.RefreshTokenInfo
+import com.msa.identityservice.auth.token.enums.Role
+import com.msa.identityservice.config.properties.JwtProperties
+import com.msa.identityservice.exception.BusinessErrorCode
+import com.msa.identityservice.jooq.enums.MemberStatus
+import com.msa.identityservice.member.repository.MemberRepository
+import io.jsonwebtoken.ExpiredJwtException
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+
+
+@Service
+class AuthService(
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val requestContext: RequestContext,
+    private val jwtProperties: JwtProperties,
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val atomicLoginScript: RedisScript<Long>,
+    private val objectMapper: ObjectMapper
+) {
+
+    fun login(loginRequestInfo: LoginRequestInfo): LoginAuthToken {
+        // 1. 사용자 인증
+        val loginUserId = validLoginUser(
+            role = loginRequestInfo.role,
+            email = loginRequestInfo.email,
+            password = loginRequestInfo.password
+        )
+
+        // 2. 인증 토큰 생성 및 저장
+        return generateAuthToken(
+            userId = loginUserId,
+            email = loginRequestInfo.email,
+            role = loginRequestInfo.role,
+            deviceId = loginRequestInfo.deviceId
+        )
+    }
+
+    private fun validLoginUser(
+        role: Role,
+        email: String,
+        password: String,
+    ): Long {
+        var userId = 0L
+
+        if (role == Role.MEMBER) {
+            val member = memberRepository.findByStatusAndEmail(MemberStatus.ACTIVE, email)
+                ?: throw BusinessErrorCode.BAD_REQUEST.exception("존재하지 않는 이메일입니다.")
+
+            if (!passwordEncoder.matches(password, member.password)) {
+                throw BusinessErrorCode.UNAUTHORIZED.exception("비밀번호가 일치하지 않습니다.")
+            }
+            userId = member.id
+        }
+
+        return userId
+    }
+
+    private fun generateAuthToken(
+        userId: Long,
+        email: String,
+        role: Role,
+        deviceId: String,
+        loginAt: Instant = Instant.now()
+    ): LoginAuthToken {
+        // AccessToken 생성
+        val now = Instant.now()
+        val accessTokenExpiration = now.plus(Duration.ofHours(jwtProperties.accessTokenExpirationHours))
+        val accessToken = jwtTokenProvider.generateJsonWebToken(
+            issuedAt = Date.from(now),
+            expiration = Date.from(accessTokenExpiration),
+            userId = userId,
+            email = email,
+            role = role,
+            deviceId = deviceId
+        )
+
+        // RefreshToken 생성
+        val refreshTokenExpiration = now.plus(Duration.ofHours(jwtProperties.refreshTokenExpirationHours))
+        val refreshToken = jwtTokenProvider.generateJsonWebToken(
+            issuedAt = Date.from(now),
+            expiration = Date.from(refreshTokenExpiration),
+            userId = userId,
+            email = email,
+            role = role,
+            deviceId = deviceId
+        )
+
+        // --- Lua 스크립트 실행을 위한 파라미터 준비 ---
+        val activeTokenKey = getActiveKey(
+            role = role,
+            userId = userId,
+            deviceId = deviceId
+        )
+        val accessTokenTtl = Duration.between(now, accessTokenExpiration).seconds
+        val sessionAgesKey = getSessionKey(role, userId)
+        val refreshTokensKey = getRefreshTokenKey(role, userId)
+        val refreshTokenExpiresAt = refreshTokenExpiration.epochSecond.toString()
+        val refreshTokenInfo = RefreshTokenInfo(
+            token = refreshToken,
+            loginAt = loginAt,
+            lastActivityAt = now,
+            expiresAt = refreshTokenExpiration,
+        )
+        val sessionInfoJson = ObjectMapper().registerModule(JavaTimeModule()).writeValueAsString(refreshTokenInfo)
+        val deleteActiveKeyPrefix = "$ACTIVE_KEY_PREFIX:${role.name.lowercase()}:$userId"
+
+        // --- 원자적 스크립트 실행 ---
+        redisTemplate.execute(
+            atomicLoginScript,
+            listOf(sessionAgesKey, refreshTokensKey, activeTokenKey),
+            jwtProperties.maxDeviceCount.toString(),
+            deviceId,
+            refreshTokenExpiresAt,
+            sessionInfoJson,
+            userId.toString(),
+            accessTokenTtl.toString(),
+            deleteActiveKeyPrefix
+        )
+
+        // For AccessToken Header Setting
+        val accessTokenHeaderValue = "${RequestContext.AUTH_HEADER_PREFIX}$accessToken"
+        val accessTokenHeader = AccessTokenHeader(
+            name = RequestContext.AUTH_HEADER_NAME,
+            value = accessTokenHeaderValue
+        )
+
+        // For RefreshToken Cookie Setting
+        val refreshTokenCookie = RefreshTokenCookie(
+            name = RequestContext.REFRESH_COOKIE_NAME,
+            value = refreshToken,
+            refreshDuration = Duration.between(Instant.now(), refreshTokenExpiration)
+        )
+
+        return LoginAuthToken(
+            accessTokenHeader = accessTokenHeader,
+            refreshTokenCookie = refreshTokenCookie
+        )
+    }
+
+    fun tokenReissue(): LoginAuthToken {
+        // 1. AccessToken 유효성 검사
+        val accessToken = requestContext.getAccessToken()
+        val tokenAuthInfo = try {
+            jwtTokenProvider.extractAuthInfo(accessToken)
+        } catch (expiredJwtException: ExpiredJwtException) {
+            // AccessToken 만료된 경우에도 토큰 재발급을 위해 예외에서 정보 추출
+            jwtTokenProvider.extractAuthInfo(expiredJwtException)
+        }
+
+        // 2. RefreshToken 유효성 검사
+        val refreshToken = requestContext.getRefreshToken()
+        val refreshTokenInfo = checkStoredRefreshTokenThrow(
+            refreshToken = refreshToken,
+            role = tokenAuthInfo.role,
+            userId = tokenAuthInfo.userId,
+            deviceId = tokenAuthInfo.deviceId
+        )
+
+        // 3. 인증 토큰 재발급
+        return generateAuthToken(
+            userId = tokenAuthInfo.userId,
+            email = tokenAuthInfo.email,
+            role = tokenAuthInfo.role,
+            deviceId = tokenAuthInfo.deviceId,
+            loginAt = refreshTokenInfo.loginAt
+        )
+    }
+
+    private fun checkStoredRefreshTokenThrow(
+        refreshToken: String,
+        role: Role,
+        userId: Long,
+        deviceId: String
+    ): RefreshTokenInfo {
+        val key = getRefreshTokenKey(role, userId)
+        val refreshTokenInfoString = redisTemplate.opsForHash<String, String>().get(key, deviceId)
+            ?: throw BusinessErrorCode.UNAUTHORIZED.exception("인증 세션 정보가 존재하지 않습니다.")
+        val refreshTokenInfo = objectMapper.readValue(refreshTokenInfoString, RefreshTokenInfo::class.java)
+
+        if (refreshTokenInfo.token != refreshToken) {
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")
+        }
+
+        return refreshTokenInfo
+    }
+
+    private fun getRefreshTokenKey(role: Role, userId: Long) = "$REFRESH_TOKEN_PREFIX:${role.name.lowercase()}:$userId"
+
+    private fun getActiveKey(role: Role, userId: Long, deviceId: String) =
+        "$ACTIVE_KEY_PREFIX:${role.name.lowercase()}:$userId:$deviceId"
+
+    private fun getSessionKey(role: Role, userId: Long) = "$SESSIONS_AGES_PREFIX:${role.name.lowercase()}:${userId}"
+
+    companion object {
+        const val SESSIONS_AGES_PREFIX = "sessions_ages"
+        const val ACTIVE_KEY_PREFIX = "active"
+        const val REFRESH_TOKEN_PREFIX = "refresh_token"
+    }
+
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/service/dto/LoginRequestInfo.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/service/dto/LoginRequestInfo.kt
@@ -1,0 +1,10 @@
+package com.msa.identityservice.auth.service.dto
+
+import com.msa.identityservice.auth.token.enums.Role
+
+data class LoginRequestInfo(
+    val email: String,
+    val password: String,
+    val role: Role,
+    val deviceId: String
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/JwtTokenProvider.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/JwtTokenProvider.kt
@@ -1,0 +1,95 @@
+package com.msa.identityservice.auth.token
+
+import com.msa.identityservice.auth.token.dto.TokenAuthInfo
+import com.msa.identityservice.auth.token.enums.Role
+import com.msa.identityservice.config.properties.JwtProperties
+import com.msa.identityservice.exception.BusinessErrorCode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.*
+
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class JwtTokenProvider(
+    private val jwtProperties: JwtProperties
+) {
+
+    fun generateJsonWebToken(
+        issuedAt: Date,
+        expiration: Date,
+        userId: Long,
+        email: String,
+        role: Role,
+        deviceId: String
+    ): String {
+        val key = Keys.hmacShaKeyFor(jwtProperties.secretKey.toByteArray(StandardCharsets.UTF_8))
+
+        return Jwts.builder()
+            .header()
+            .and()
+            .issuer("identity-service")
+            .issuedAt(issuedAt)
+            .expiration(expiration)
+            .subject(userId.toString())
+            .claim("role", role.name)
+            .claim("email", email)
+            .claim("deviceId", deviceId)
+            .signWith(key)
+            .compact()
+    }
+
+    fun extractAuthInfo(token: String): TokenAuthInfo {
+        try {
+            val claims = getClaims(token)
+
+            return extractAuthInfo(claims)
+        } catch (e: Exception) {
+            logger.error { "Extract AuthInfo exception: $e" }
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")
+        }
+    }
+
+    private fun getClaims(token: String): Claims {
+        val key = Keys.hmacShaKeyFor(jwtProperties.secretKey.toByteArray(StandardCharsets.UTF_8))
+
+        return Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .payload
+    }
+
+    private fun extractAuthInfo(claims: Claims): TokenAuthInfo {
+        val userId = claims.subject.toLong()
+        val role = claims.get("role", String::class.java)
+        val email = claims.get("email", String::class.java)
+        val expiration = claims.expiration
+        val deviceId = claims.get("deviceId", String::class.java)
+
+        return TokenAuthInfo(
+            userId = userId,
+            email = email,
+            role = Role.valueOf(role),
+            expiresAt = expiration,
+            deviceId = deviceId
+        )
+    }
+
+    fun extractAuthInfo(expiredJwtException: ExpiredJwtException): TokenAuthInfo {
+        try {
+            val claims = expiredJwtException.claims
+
+            return extractAuthInfo(claims)
+        } catch (e: Exception) {
+            logger.error { "Extract AuthInfo exception (ExpiredJwtException): $e" }
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")
+        }
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
@@ -17,29 +17,30 @@ class RequestContext(
 
     fun getRefreshToken(): String {
         if (request.cookies == null) {
-            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 존재하지 않습니다.")
+            throw BusinessErrorCode.UNAUTHORIZED.exception(UNAUTHORIZED_MESSAGE)
         }
 
         return Arrays.stream(request.cookies)
             .filter { c -> c.name.equals(REFRESH_COOKIE_NAME) }
             .map { obj: Cookie -> obj.value }
             .findFirst()
-            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 존재하지 않습니다.") }
+            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception(UNAUTHORIZED_MESSAGE) }
     }
 
     fun getAccessToken(): String {
         val authHeader = request.getHeader(AUTH_HEADER_NAME)
         if (authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
-            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 존재하지 않습니다.")
+            throw BusinessErrorCode.UNAUTHORIZED.exception(UNAUTHORIZED_MESSAGE)
         }
 
         return authHeader.substring(AUTH_HEADER_PREFIX.length)
     }
 
     companion object {
-        const val REFRESH_COOKIE_NAME: String = "refreshToken"
-        const val AUTH_HEADER_NAME: String = "Authorization"
-        const val AUTH_HEADER_PREFIX: String = "Bearer "
+        const val REFRESH_COOKIE_NAME = "refreshToken"
+        const val AUTH_HEADER_NAME = "Authorization"
+        const val AUTH_HEADER_PREFIX = "Bearer "
+        const val UNAUTHORIZED_MESSAGE = "인증 정보가 존재하지 않습니다."
     }
 
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
@@ -17,20 +17,20 @@ class RequestContext(
 
     fun getRefreshToken(): String {
         if (request.cookies == null) {
-            throw BusinessErrorCode.UNAUTHORIZED.exception(UNAUTHORIZED_MESSAGE)
+            throw BusinessErrorCode.UNAUTHORIZED.exception(NOT_FOUND_TOKEN_MESSAGE)
         }
 
         return Arrays.stream(request.cookies)
             .filter { c -> c.name.equals(REFRESH_COOKIE_NAME) }
             .map { obj: Cookie -> obj.value }
             .findFirst()
-            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception(UNAUTHORIZED_MESSAGE) }
+            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception(NOT_FOUND_TOKEN_MESSAGE) }
     }
 
     fun getAccessToken(): String {
         val authHeader = request.getHeader(AUTH_HEADER_NAME)
         if (authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
-            throw BusinessErrorCode.UNAUTHORIZED.exception(UNAUTHORIZED_MESSAGE)
+            throw BusinessErrorCode.UNAUTHORIZED.exception(NOT_FOUND_TOKEN_MESSAGE)
         }
 
         return authHeader.substring(AUTH_HEADER_PREFIX.length)
@@ -40,7 +40,7 @@ class RequestContext(
         const val REFRESH_COOKIE_NAME = "refreshToken"
         const val AUTH_HEADER_NAME = "Authorization"
         const val AUTH_HEADER_PREFIX = "Bearer "
-        const val UNAUTHORIZED_MESSAGE = "인증 정보가 존재하지 않습니다."
+        const val NOT_FOUND_TOKEN_MESSAGE = "인증 정보가 존재하지 않습니다."
     }
 
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
@@ -17,20 +17,20 @@ class RequestContext(
 
     fun getRefreshToken(): String {
         if (request.cookies == null) {
-            throw BusinessErrorCode.UNAUTHORIZED.exception(NOT_FOUND_TOKEN_MESSAGE)
+            throw BusinessErrorCode.UNAUTHORIZED.exception(CONTEXT_NOT_FOUND_MESSAGE)
         }
 
         return Arrays.stream(request.cookies)
             .filter { c -> c.name.equals(REFRESH_COOKIE_NAME) }
             .map { obj: Cookie -> obj.value }
             .findFirst()
-            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception(NOT_FOUND_TOKEN_MESSAGE) }
+            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception(CONTEXT_NOT_FOUND_MESSAGE) }
     }
 
     fun getAccessToken(): String {
         val authHeader = request.getHeader(AUTH_HEADER_NAME)
         if (authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
-            throw BusinessErrorCode.UNAUTHORIZED.exception(NOT_FOUND_TOKEN_MESSAGE)
+            throw BusinessErrorCode.UNAUTHORIZED.exception(CONTEXT_NOT_FOUND_MESSAGE)
         }
 
         return authHeader.substring(AUTH_HEADER_PREFIX.length)
@@ -40,7 +40,7 @@ class RequestContext(
         const val REFRESH_COOKIE_NAME = "refreshToken"
         const val AUTH_HEADER_NAME = "Authorization"
         const val AUTH_HEADER_PREFIX = "Bearer "
-        const val NOT_FOUND_TOKEN_MESSAGE = "인증 정보가 존재하지 않습니다."
+        const val CONTEXT_NOT_FOUND_MESSAGE = "인증 정보가 존재하지 않습니다."
     }
 
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/RequestContext.kt
@@ -1,0 +1,45 @@
+package com.msa.identityservice.auth.token
+
+import com.msa.identityservice.exception.BusinessErrorCode
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.context.annotation.ScopedProxyMode
+import org.springframework.stereotype.Component
+import org.springframework.web.context.annotation.RequestScope
+import java.util.*
+
+
+@Component
+@RequestScope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+class RequestContext(
+    private val request: HttpServletRequest
+) {
+
+    fun getRefreshToken(): String {
+        if (request.cookies == null) {
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 존재하지 않습니다.")
+        }
+
+        return Arrays.stream(request.cookies)
+            .filter { c -> c.name.equals(REFRESH_COOKIE_NAME) }
+            .map { obj: Cookie -> obj.value }
+            .findFirst()
+            .orElseThrow { BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 존재하지 않습니다.") }
+    }
+
+    fun getAccessToken(): String {
+        val authHeader = request.getHeader(AUTH_HEADER_NAME)
+        if (authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 존재하지 않습니다.")
+        }
+
+        return authHeader.substring(AUTH_HEADER_PREFIX.length)
+    }
+
+    companion object {
+        const val REFRESH_COOKIE_NAME: String = "refreshToken"
+        const val AUTH_HEADER_NAME: String = "Authorization"
+        const val AUTH_HEADER_PREFIX: String = "Bearer "
+    }
+
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/AccessTokenAuthInfo.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/AccessTokenAuthInfo.kt
@@ -1,0 +1,13 @@
+package com.msa.identityservice.auth.token.dto
+
+import com.msa.identityservice.auth.token.enums.Role
+import java.util.*
+
+
+data class AccessTokenAuthInfo(
+    val jti: String,
+    val userId: Long,
+    val email: String,
+    val role: Role,
+    val expiresAt: Date,
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/AccessTokenHeader.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/AccessTokenHeader.kt
@@ -1,0 +1,6 @@
+package com.msa.identityservice.auth.token.dto
+
+data class AccessTokenHeader(
+    val name: String,
+    val value: String
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/LoginAuthToken.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/LoginAuthToken.kt
@@ -1,0 +1,6 @@
+package com.msa.identityservice.auth.token.dto
+
+data class LoginAuthToken(
+    val accessTokenHeader: AccessTokenHeader,
+    val refreshTokenCookie: RefreshTokenCookie
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/RefreshTokenCookie.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/RefreshTokenCookie.kt
@@ -1,0 +1,10 @@
+package com.msa.identityservice.auth.token.dto
+
+import java.time.Duration
+
+
+data class RefreshTokenCookie(
+    val name: String,
+    val value: String,
+    val refreshDuration: Duration
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/RefreshTokenInfo.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/RefreshTokenInfo.kt
@@ -1,0 +1,10 @@
+package com.msa.identityservice.auth.token.dto
+
+import java.time.Instant
+
+data class RefreshTokenInfo(
+    val token: String,
+    val loginAt: Instant,
+    val lastActivityAt: Instant,
+    val expiresAt: Instant,
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/TokenAuthInfo.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/dto/TokenAuthInfo.kt
@@ -1,0 +1,13 @@
+package com.msa.identityservice.auth.token.dto
+
+import com.msa.identityservice.auth.token.enums.Role
+import java.util.*
+
+
+data class TokenAuthInfo(
+    val userId: Long,
+    val role: Role,
+    val email: String,
+    val deviceId: String,
+    val expiresAt: Date,
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/enums/Role.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/auth/token/enums/Role.kt
@@ -1,0 +1,7 @@
+package com.msa.identityservice.auth.token.enums
+
+enum class Role {
+    MEMBER, // 일반 사용자
+    HOST,   // 숙소 관리자
+    ADMIN   // 플랫폼 관리자
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/config/AnnotationConfig.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/config/AnnotationConfig.kt
@@ -1,0 +1,17 @@
+package com.msa.identityservice.config
+
+import com.msa.identityservice.annotation.LoginUserArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+
+@Configuration
+class AnnotationConfig(
+    private val loginUserArgumentResolver: LoginUserArgumentResolver
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(loginUserArgumentResolver)
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/config/RedisConfig.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/config/RedisConfig.kt
@@ -1,0 +1,52 @@
+package com.msa.identityservice.config
+
+import com.msa.identityservice.config.properties.RedisProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+
+@Configuration
+class RedisConfig(
+    private val redisProperties: RedisProperties
+) {
+
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory {
+        val redisHost = redisProperties.host
+        val redisPort = redisProperties.port
+        val redisPassword = redisProperties.password
+
+        val redisStandaloneConfiguration = RedisStandaloneConfiguration(redisHost, redisPort)
+        redisStandaloneConfiguration.setPassword(redisPassword)
+
+        return LettuceConnectionFactory(redisStandaloneConfiguration)
+    }
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        val redisTemplate = RedisTemplate<String, Any>()
+        redisTemplate.connectionFactory = redisConnectionFactory()
+
+        // Key는 String, Value는 모든 객체를 저장할 수 있도록 설정
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = StringRedisSerializer()
+        redisTemplate.hashKeySerializer = StringRedisSerializer()
+        redisTemplate.hashValueSerializer = StringRedisSerializer()
+
+        return redisTemplate
+    }
+
+    @Bean
+    fun evictAndAddSessionScript(): DefaultRedisScript<Long> {
+        val script = DefaultRedisScript<Long>()
+        script.setLocation(ClassPathResource("scripts/atomic-login.lua"))
+        script.resultType = Long::class.java
+        return script
+    }
+}

--- a/identity-service/src/main/kotlin/com/msa/identityservice/config/SecurityConfig.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/config/SecurityConfig.kt
@@ -21,9 +21,11 @@ class SecurityConfig {
         http.csrf { it.disable() }
             .authorizeHttpRequests {
                 it.requestMatchers(HttpMethod.POST, "/members").permitAll()
+                    .requestMatchers("/auth/**").permitAll()
                     .anyRequest().authenticated()
             }
 
         return http.build()
     }
+
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/config/properties/JwtProperties.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/config/properties/JwtProperties.kt
@@ -1,0 +1,27 @@
+package com.msa.identityservice.config.properties
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+
+@Validated
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    @field:NotBlank(message = "jwt 시크릿 키가 비어있을 수 없습니다.")
+    val secretKey: String,
+
+    @field:Min(1, message = "Access Token 만료 시간은 최소 1시간 이상이어야 합니다.")
+    @field:Max(10, message = "Access Token 만료 시간은 최대 10시간 넘을 수 없습니다.")
+    val accessTokenExpirationHours: Long,
+
+    @field:Min(23, message = "Access Token 만료 시간은 최소 23시간 이상이어야 합니다.")
+    @field:Max(49, message = "Access Token 만료 시간은 최대 49시간 넘을 수 없습니다.")
+    val refreshTokenExpirationHours: Long,
+
+    @field:Min(1, message = "jwt 토큰 발급이 가능한 최대 기기 개수는 최소 1개 이상이어야 합니다.")
+    @field:Max(10, message = "jwt 토큰 발급이 가능한 최대 기기 개수는 최대 10개를 넘을 수 없습니다.")
+    val maxDeviceCount: Int
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/config/properties/RedisProperties.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/config/properties/RedisProperties.kt
@@ -1,0 +1,21 @@
+package com.msa.identityservice.config.properties
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+@Validated
+@ConfigurationProperties(prefix = "spring.data.redis")
+data class RedisProperties(
+    @field:NotBlank(message = "redis host가 비어있을 수 없습니다.")
+    val host: String,
+
+    @field:Min(6000, message = "redis port는 최소 6000 이상이어야 합니다.")
+    @field:Max(32000, message = "redis port는 최대 32000 넘을 수 없습니다.")
+    val port: Int,
+
+    @field:NotBlank(message = "redis password가 비어있을 수 없습니다.")
+    val password: String,
+)

--- a/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessErrorCode.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessErrorCode.kt
@@ -3,7 +3,11 @@ package com.msa.identityservice.exception
 import org.springframework.http.HttpStatus
 
 
-enum class BusinessErrorCode(private val httpStatus: HttpStatus, private val defaultMessage: String) {
+enum class BusinessErrorCode(
+    val httpStatus: HttpStatus,
+    val defaultMessage: String
+) {
+
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했거나, 요청 값이 잘못되었습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했거나, 요청 값이 잘못되었습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나, 인증에 실패했습니다."),
@@ -12,15 +16,8 @@ enum class BusinessErrorCode(private val httpStatus: HttpStatus, private val def
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하거나, 처리된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
 
-    fun httpStatus(): HttpStatus {
-        return httpStatus
-    }
-
-    fun defaultMessage(): String {
-        return defaultMessage
-    }
-
     fun exception(message: String?): BusinessException {
-        return BusinessException(this, message ?: this.defaultMessage)
+        return BusinessException(this, message ?: defaultMessage)
     }
+    
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessException.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/exception/BusinessException.kt
@@ -3,16 +3,13 @@ package com.msa.identityservice.exception
 import org.springframework.http.HttpStatus
 
 
-class BusinessException (
-    private val errorCode: BusinessErrorCode,
+class BusinessException(
+    val errorCode: BusinessErrorCode,
     override val message: String
 ) : RuntimeException(message) {
-
-    fun errorCode(): BusinessErrorCode {
-        return errorCode
-    }
-
+    
     fun httpStatus(): HttpStatus {
-        return errorCode.httpStatus()
+        return errorCode.httpStatus
     }
+
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/infrastructure/IdGenerator.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/infrastructure/IdGenerator.kt
@@ -9,4 +9,5 @@ class IdGenerator {
     fun generate(): Long {
         return TsidCreator.getTsid().toLong()
     }
+    
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/MemberController.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/MemberController.kt
@@ -6,24 +6,32 @@ import com.msa.identityservice.member.service.MemberService
 import com.msa.identityservice.support.response.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/members")
 class MemberController(
     private val memberService: MemberService
 ) {
+
     @PostMapping()
     @ResponseStatus(HttpStatus.CREATED)
-    fun register(@Valid @RequestBody request: MemberRegistrationRequest): ApiResponse<MemberRegistrationResponse> {
+    fun register(
+        @Valid @RequestBody
+        request: MemberRegistrationRequest
+    ): ApiResponse<MemberRegistrationResponse> {
         val registerMemberDto = request.toRegisterMemberDto()
         val newMember = memberService.register(registerMemberDto)
-        val response = MemberRegistrationResponse(id = newMember.id, email = newMember.email)
 
-        return ApiResponse.create(message = "회원 가입에 성공했습니다.", response)
+        val response = MemberRegistrationResponse(
+            id = newMember.id,
+            email = newMember.email
+        )
+
+        return ApiResponse.create(
+            message = "회원 가입에 성공했습니다.",
+            data = response
+        )
     }
+
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/controller/request/MemberRegistrationRequest.kt
@@ -8,23 +8,23 @@ import jakarta.validation.constraints.Pattern
 data class MemberRegistrationRequest(
     @field:NotBlank(message = "이메일은 필수입니다.")
     @field:Email(message = "올바른 이메일 형식이 아닙니다.")
-    val email: String,
+    val email: String?,
 
     @field:NotBlank(message = "비밀번호는 필수입니다.")
-    @field:Pattern(regexp = PW_PATTERN,message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
-    val password: String,
+    @field:Pattern(regexp = PW_PATTERN, message = "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.")
+    val password: String?,
 
     @field:NotBlank(message = "휴대폰 번호는 필수입니다.")
     @field:Pattern(regexp = PHONE_NUMBER_PATTERN, message = "올바른 휴대폰 번호 형식이 아닙니다. (010-XXXX-XXXX)")
-    val phoneNumber: String
+    val phoneNumber: String?
 ) {
-    fun toRegisterMemberDto(): RegisterMemberDto {
-        return RegisterMemberDto(
-            email = this.email,
-            password = this.password,
-            phoneNumber = this.phoneNumber
-        )
-    }
+
+    fun toRegisterMemberDto() = RegisterMemberDto(
+        email = email!!,
+        password = password!!,
+        phoneNumber = phoneNumber!!
+    )
+
 
     companion object {
         // 비밀번호 정책 검증 정규식 (최소 8자, 영문, 숫자, 특수문자 각 1개 이상 포함)
@@ -33,4 +33,5 @@ data class MemberRegistrationRequest(
         // 대한민국 휴대폰 번호 형식 검증 정규식 (010-XXXX-XXXX)
         private const val PHONE_NUMBER_PATTERN = "^010-\\d{4}-\\d{4}$"
     }
+
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/repository/MemberRepository.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/repository/MemberRepository.kt
@@ -10,13 +10,13 @@ import org.springframework.stereotype.Repository
 class MemberRepository(
     private val dsl: DSLContext
 ) {
-    fun save(member: Member) {
+
+    fun insert(member: Member) {
         dsl.insertInto(MEMBER)
             .set(MEMBER.ID, member.id)
             .set(MEMBER.EMAIL, member.email)
             .set(MEMBER.PASSWORD, member.password)
             .set(MEMBER.PHONE_NUMBER, member.phoneNumber)
-            .set(MEMBER.STATUS, member.status)
             .execute()
     }
 
@@ -26,9 +26,12 @@ class MemberRepository(
             .fetchOneInto(Member::class.java)
     }
 
-    fun findActiveMemberByEmail(email: String): Member? {
+    fun findByStatusAndEmail(status: MemberStatus, email: String): Member? {
         return dsl.selectFrom(MEMBER)
-            .where(MEMBER.EMAIL.eq(email).and(MEMBER.STATUS.eq(MemberStatus.ACTIVE)))
+            .where(
+                MEMBER.STATUS.eq(status).and(MEMBER.EMAIL.eq(email))
+            )
             .fetchOneInto(Member::class.java)
     }
+
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/member/service/dto/RegisterMemberDto.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/member/service/dto/RegisterMemberDto.kt
@@ -1,6 +1,5 @@
 package com.msa.identityservice.member.service.dto
 
-import com.msa.identityservice.jooq.enums.MemberStatus
 import com.msa.identityservice.jooq.tables.pojos.Member
 
 
@@ -9,13 +8,14 @@ data class RegisterMemberDto(
     val password: String,
     val phoneNumber: String
 ) {
+
     fun toNewMember(newId: Long, encoderPassword: String): Member {
         return Member(
             id = newId,
-            email = email,
+            email = email.lowercase(),
             password = encoderPassword,
-            phoneNumber = phoneNumber,
-            status = MemberStatus.ACTIVE
+            phoneNumber = phoneNumber
         )
     }
+
 }

--- a/identity-service/src/main/kotlin/com/msa/identityservice/support/response/ApiResponse.kt
+++ b/identity-service/src/main/kotlin/com/msa/identityservice/support/response/ApiResponse.kt
@@ -6,6 +6,7 @@ data class ApiResponse<T>(
     val message: String,
     val data: T?
 ) {
+
     companion object {
         fun <T> create(message: String, data: T): ApiResponse<T> {
             return ApiResponse(true, "create", message, data)
@@ -24,7 +25,8 @@ data class ApiResponse<T>(
         }
 
         fun error(code: String, message: String): ApiResponse<Nothing> {
-            return ApiResponse( false, code, message, null)
+            return ApiResponse(false, code, message, null)
         }
     }
+    
 }

--- a/identity-service/src/main/resources/application.yml
+++ b/identity-service/src/main/resources/application.yml
@@ -4,6 +4,11 @@ server:
 spring:
   application:
     name: identity-service
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:30079}
+      password: ${REDIS_PASSWORD:your-redis-password}
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:30306/identity-db}
     username: ${DB_USER:root}
@@ -14,7 +19,17 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true # 기존에 테이블이 있는 DB에 처음 적용할 때, 현재 상태를 기준으로 삼는 설정
+  jackson:
+    deserialization:
+      read-unknown-enum-values-as-null: true
 
 logging:
   level:
     org.jooq.tools.LoggerListener: TRACE
+    org.springframework.data.redis: DEBUG
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY:this-is-a-very-long-and-secure-secret-key-for-hs256-algorithm}
+  access-token-expiration-hours: 1
+  refresh-token-expiration-hours: 24
+  max-device-count: 5

--- a/identity-service/src/main/resources/db/migration/V1__Create_member_table.sql
+++ b/identity-service/src/main/resources/db/migration/V1__Create_member_table.sql
@@ -1,15 +1,15 @@
--- V1__Create_member_table.sql
-
-CREATE TABLE `member` (
-    -- Snowflake ID는 64비트 정수이므로 BIGINT로 설정
-    `id` BIGINT NOT NULL,
-    `email` VARCHAR(255) NOT NULL COMMENT '로그인 이메일',
-    `password` VARCHAR(255) NOT NULL COMMENT '해싱된 비밀번호',
-    `phone_number` VARCHAR(20) NULL COMMENT '휴대폰 번호',
-    `status` ENUM('ACTIVE', 'DELETED') NOT NULL DEFAULT 'ACTIVE',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+CREATE TABLE `member`
+(
+    `id`                BIGINT                     NOT NULL,
+    `email`             VARCHAR(255)               NOT NULL COMMENT '로그인 이메일',
+    `password`          VARCHAR(255)               NOT NULL COMMENT '해싱된 비밀번호',
+    `phone_number`      VARCHAR(20)                NULL COMMENT '휴대폰 번호',
+    `status`            ENUM ('ACTIVE', 'DELETED') NOT NULL DEFAULT 'ACTIVE',
+    `tokens_valid_from` DATETIME                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `created_at`        DATETIME                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`        DATETIME                   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
-    -- email을 이용한 조회가 많으므로 UNIQUE INDEX 추가
-    UNIQUE INDEX `uk_member_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+    UNIQUE INDEX `uk_member_email` (`email`) -- email을 이용한 조회가 많으므로 UNIQUE INDEX 추가
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/identity-service/src/main/resources/scripts/atomic-login.lua
+++ b/identity-service/src/main/resources/scripts/atomic-login.lua
@@ -1,0 +1,32 @@
+-- KEYS[1]: session_ages ZSET key
+-- KEYS[2]: refresh_tokens HASH key
+-- KEYS[3]: active_tokens key
+
+-- ARGV[1]: maxDevices
+-- ARGV[2]: newDeviceId
+-- ARGV[3]: newExpiresAtTimestamp
+-- ARGV[4]: newSessionValue ("{jti}:{refreshToken}")
+-- ARGV[5]: userId
+-- ARGV[6]: accessTokenTtlInSeconds
+-- ARGV[7]: deleteActiveKeyPrefix
+
+-- 최대 기기 수에 도달했거나 초과했다면
+if redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[1]) then
+    -- 1. ZSET에서 가장 오래된 deviceId를 가져오고 제거
+    local oldest_device_id = redis.call('ZPOPMIN', KEYS[1])[1]
+    if oldest_device_id then
+        -- 2. HASH에서 해당 deviceId의 리프레시 토큰 삭제
+        redis.call('HDEL', KEYS[2], oldest_device_id)
+
+        -- 3. ZSET에서 가져온 deviceId로 바로 삭제할 활성 토큰 키를 만듦
+        local active_key_to_delete = ARGV[7] .. ":" .. oldest_device_id
+        redis.call('DEL', active_key_to_delete)
+    end
+end
+
+-- 새 세션 정보 추가
+redis.call('ZADD', KEYS[1], ARGV[3], ARGV[2])
+redis.call('HSET', KEYS[2], ARGV[2], ARGV[4])
+redis.call('SET', KEYS[3], ARGV[5], 'EX', ARGV[6])
+
+return 1

--- a/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
@@ -1,0 +1,145 @@
+package com.msa.identityservice.auth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.msa.identityservice.auth.controller.request.LoginRequest
+import com.msa.identityservice.auth.service.AuthService.Companion.ACTIVE_KEY_PREFIX
+import com.msa.identityservice.auth.service.AuthService.Companion.REFRESH_TOKEN_PREFIX
+import com.msa.identityservice.auth.token.JwtTokenProvider
+import com.msa.identityservice.auth.token.enums.Role
+import com.msa.identityservice.jooq.enums.MemberStatus
+import com.msa.identityservice.jooq.tables.pojos.Member
+import com.msa.identityservice.member.repository.MemberRepository
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.Test
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthControllerIntegrationTest @Autowired constructor(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val redisTemplate: RedisTemplate<String, String>
+) {
+    lateinit var testMember: Member
+
+    @BeforeEach
+    fun setup() {
+        testMember = Member(
+            id = 1L,
+            email = "test@example.com",
+            password = passwordEncoder.encode("password1!"),
+            status = MemberStatus.ACTIVE,
+        )
+        memberRepository.insert(testMember)
+    }
+
+    @Test
+    fun `정상적인 정보로 로그인 요청 시, 토큰이 발급되고 세션 정보가 Redis에 저장된다`() {
+        // Given
+        val deviceId = "test-device-1"
+        val request = LoginRequest(
+            email = "test@example.com",
+            password = "password1!",
+            role = Role.MEMBER,
+            deviceId = deviceId
+        )
+
+        // When
+        val result = mockMvc.post("/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isNoContent() } // 204 No Content
+            header { exists("Authorization") }
+            cookie { exists("refreshToken") }
+        }.andReturn()
+
+        // Then: Token 검증 및 Redis에 데이터가 올바르게 저장되었는지 직접 검증
+        val accessToken = result.response.getHeader("Authorization")!!.substring(7)
+        val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
+        tokenAuthInfo.userId shouldBe testMember.id
+        tokenAuthInfo.role shouldBe Role.MEMBER
+        tokenAuthInfo.deviceId shouldBe deviceId
+        tokenAuthInfo.email shouldBe testMember.email
+
+        val userRefreshTokensKey = "$REFRESH_TOKEN_PREFIX:${Role.MEMBER.name.lowercase()}:${testMember.id}"
+        val savedRefreshTokenInfo = redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, deviceId)
+        savedRefreshTokenInfo shouldNotBe null
+
+        val activeTokenKey = "$ACTIVE_KEY_PREFIX:${Role.MEMBER.name.lowercase()}:${testMember.id}:$deviceId"
+        val savedActiveToken = redisTemplate.opsForValue().get(activeTokenKey)
+        savedActiveToken shouldBe testMember.id.toString()
+    }
+
+    @Test
+    fun `유효한 리프레시 토큰으로 토큰 재발급 요청 시, 새로운 토큰들이 발급된다`() {
+        // Given: 먼저 로그인을 수행하여 유효한 토큰들을 발급받음
+        val deviceId = "test-device-2"
+        val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(deviceId)
+
+        // When
+        val result = mockMvc.get("/auth/refresh") {
+            cookie(refreshTokenCookie)
+            header("Authorization", "Bearer $accessToken") // 재발급 시에도 만료된 AccessToken은 보내야 함
+        }.andExpect {
+            status { isNoContent() }
+        }.andReturn()
+
+        // Then
+        val newAccessToken = result.response.getHeader("Authorization")
+        val newRefreshTokenCookie = result.response.getCookie("refreshToken")
+
+        newAccessToken shouldNotBe "Bearer $accessToken"
+        newRefreshTokenCookie?.value shouldNotBe refreshTokenCookie.value
+    }
+
+    @Test
+    fun `유효한 액세스 토큰으로 내 정보 조회 요청 시, 사용자 정보가 반환된다`() {
+        // Given
+        val deviceId = "test-device-3"
+        val (accessToken, _) = performLoginAndGetTokens(deviceId)
+
+        // When & Then
+        mockMvc.get("/auth/me") {
+            header("Authorization", "Bearer $accessToken")
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.userId") { value(testMember.id) }
+            jsonPath("$.data.email") { value(testMember.email) }
+            jsonPath("$.data.role") { value(Role.MEMBER.name) }
+            jsonPath("$.data.deviceId") { value(deviceId) }
+        }
+    }
+
+    // 테스트 코드 중복을 줄이기 위한 헬퍼 함수
+    private fun performLoginAndGetTokens(deviceId: String): Pair<String, Cookie> {
+        val request = LoginRequest(testMember.email, "password1!", Role.MEMBER, deviceId)
+        val result = mockMvc.post("/auth/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andReturn()
+
+        val accessToken = result.response.getHeader("Authorization")!!.substring(7)
+        val refreshTokenCookie = result.response.getCookie("refreshToken")!!
+        return Pair(accessToken, refreshTokenCookie)
+    }
+}

--- a/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
@@ -39,13 +39,14 @@ class AuthControllerIntegrationTest @Autowired constructor(
     private val redisTemplate: RedisTemplate<String, String>
 ) {
     lateinit var testMember: Member
+    val testPassword = "testPassword1!"
 
     @BeforeEach
     fun setup() {
         testMember = Member(
             id = 1L,
             email = "test@example.com",
-            password = passwordEncoder.encode("password1!"),
+            password = passwordEncoder.encode(testPassword),
             status = MemberStatus.ACTIVE,
         )
         memberRepository.insert(testMember)
@@ -56,8 +57,8 @@ class AuthControllerIntegrationTest @Autowired constructor(
         // Given
         val deviceId = "test-device-1"
         val request = LoginRequest(
-            email = "test@example.com",
-            password = "password1!",
+            email = testMember.email,
+            password = testPassword,
             role = Role.MEMBER,
             deviceId = deviceId
         )
@@ -132,7 +133,12 @@ class AuthControllerIntegrationTest @Autowired constructor(
 
     // 테스트 코드 중복을 줄이기 위한 헬퍼 함수
     private fun performLoginAndGetTokens(deviceId: String): Pair<String, Cookie> {
-        val request = LoginRequest(testMember.email, "password1!", Role.MEMBER, deviceId)
+        val request = LoginRequest(
+            email = testMember.email,
+            password = testPassword,
+            role = Role.MEMBER,
+            deviceId = deviceId
+        )
         val result = mockMvc.post("/auth/login") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(request)

--- a/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
@@ -14,12 +14,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
 @AutoConfigureMockMvc // MockMvc를 실제 서버처럼 사용하기 위한 설정
+@ActiveProfiles("test")
 @Transactional
 class MemberControllerIntegrationTest @Autowired constructor(
     private val mockMvc: MockMvc,
@@ -70,11 +72,15 @@ class MemberControllerIntegrationTest @Autowired constructor(
             email = existingEmail,
             password = "password",
             phoneNumber = "010-1234-5678",
-            status = MemberStatus.ACTIVE,
         )
-        memberRepository.save(existingMember)
 
-        val request = MemberRegistrationRequest(existingEmail, "Password123!", "010-1111-2222")
+        memberRepository.insert(existingMember)
+
+        val request = MemberRegistrationRequest(
+            email = existingEmail,
+            password = "Password123!",
+            phoneNumber = "010-1111-2222"
+        )
 
         // When & Then
         mockMvc.post("/members") {
@@ -88,4 +94,5 @@ class MemberControllerIntegrationTest @Autowired constructor(
             jsonPath("$.message") { value("이미 사용 중인 이메일입니다.") }
         }
     }
+    
 }

--- a/identity-service/src/test/resources/application-test.yml
+++ b/identity-service/src/test/resources/application-test.yml
@@ -1,6 +1,9 @@
 spring:
-  application:
-    name: identity-service
+  data:
+    redis:
+      host: ${TEST_REDIS_HOST:localhost}
+      port: ${TEST_REDIS_PORT:30079}
+      password: ${TEST_REDIS_PASSWORD:your-redis-password}
   datasource:
     url: ${TEST_DB_URL:jdbc:mysql://localhost:30306/identity-test-db}
     username: ${TEST_DB_USER:root}
@@ -12,7 +15,3 @@ spring:
     enabled: true
     baseline-on-migrate: true # 기존에 테이블이 있는 DB에 처음 적용할 때, 현재 상태를 기준으로 삼는 설정
     schemas: identity-test-db
-
-logging:
-  level:
-    org.jooq.tools.LoggerListener: TRACE

--- a/k8s/dev/infra/mysql-deploy.yml
+++ b/k8s/dev/infra/mysql-deploy.yml
@@ -79,9 +79,10 @@ kind: Service
 metadata:
   name: mysql-service
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app: mysql
   ports:
     - port: 3306
       targetPort: 3306
+      nodePort: 30306

--- a/k8s/dev/infra/redis-deploy.yml
+++ b/k8s/dev/infra/redis-deploy.yml
@@ -1,5 +1,3 @@
-# redis-deploy.yml
-
 # --- 1. Secret: Redis 비밀번호를 안전하게 저장 ---
 apiVersion: v1
 kind: Secret
@@ -7,9 +5,6 @@ metadata:
   name: redis-secret
 type: Opaque
 data:
-  # Redis 접속 비밀번호
-  # echo -n 'your-redis-password' | base64 -> eW91ci1yZWRpcy1wYXNzd29yZA==
-  # 실제 프로덕션에서는 더 강력한 비밀번호를 사용하세요.
   redis-password: eW91ci1yZWRpcy1wYXNzd29yZA==
 
 ---
@@ -20,10 +15,10 @@ metadata:
   name: redis-pvc
 spec:
   accessModes:
-    - ReadWriteOnce # 볼륨은 한 번에 하나의 노드에서만 읽기/쓰기 가능
+    - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi # 1GB의 저장 공간 요청
+      storage: 1Gi
 
 ---
 # --- 3. Deployment: Redis 컨테이너를 실행 ---
@@ -41,23 +36,30 @@ spec:
       labels:
         app: redis
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: redis-container
-          # 가벼운 Alpine Linux 기반의 Redis 이미지를 사용합니다.
           image: redis:7-alpine
           ports:
-            - containerPort: 6379 # Redis 기본 포트
-          # Redis는 환경변수가 아닌, 실행 인자로 비밀번호를 설정합니다.
-          command: ["redis-server"]
-          args: ["--requirepass", "$(REDIS_PASSWORD)"]
+            - containerPort: 6379
+          command: [ "redis-server" ]
+          args: [ "--requirepass", "$(REDIS_PASSWORD)" ]
           env:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: redis-secret
                   key: redis-password
+
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m" # 0.1 vCPU
+            limits:
+              memory: "256Mi"
+              cpu: "200m" # 0.2 vCPU
+
           volumeMounts:
-            # PVC를 컨테이너의 /data 디렉토리에 마운트하여 데이터를 보존합니다.
             - name: redis-persistent-storage
               mountPath: /data
       volumes:
@@ -72,10 +74,10 @@ kind: Service
 metadata:
   name: redis-service
 spec:
-  type: NodePort # 클러스터 내부에서만 접근 가능한 고정 IP 할당
+  type: NodePort
   selector:
-    app: redis # 'app=redis' 레이블을 가진 Pod를 대상으로 함
+    app: redis
   ports:
     - port: 6379
       targetPort: 6379
-      nodePort: 30079 # 외부에서 접근할 포트 (30000-32767 범위 내)
+      nodePort: 30079

--- a/k8s/dev/infra/redis-deploy.yml
+++ b/k8s/dev/infra/redis-deploy.yml
@@ -1,0 +1,81 @@
+# redis-deploy.yml
+
+# --- 1. Secret: Redis 비밀번호를 안전하게 저장 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-secret
+type: Opaque
+data:
+  # Redis 접속 비밀번호
+  # echo -n 'your-redis-password' | base64 -> eW91ci1yZWRpcy1wYXNzd29yZA==
+  # 실제 프로덕션에서는 더 강력한 비밀번호를 사용하세요.
+  redis-password: eW91ci1yZWRpcy1wYXNzd29yZA==
+
+---
+# --- 2. PersistentVolumeClaim (PVC): 데이터 보존을 위한 디스크 공간 요청 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce # 볼륨은 한 번에 하나의 노드에서만 읽기/쓰기 가능
+  resources:
+    requests:
+      storage: 1Gi # 1GB의 저장 공간 요청
+
+---
+# --- 3. Deployment: Redis 컨테이너를 실행 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis-container
+          # 가벼운 Alpine Linux 기반의 Redis 이미지를 사용합니다.
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379 # Redis 기본 포트
+          # Redis는 환경변수가 아닌, 실행 인자로 비밀번호를 설정합니다.
+          command: ["redis-server"]
+          args: ["--requirepass", "$(REDIS_PASSWORD)"]
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: redis-password
+          volumeMounts:
+            # PVC를 컨테이너의 /data 디렉토리에 마운트하여 데이터를 보존합니다.
+            - name: redis-persistent-storage
+              mountPath: /data
+      volumes:
+        - name: redis-persistent-storage
+          persistentVolumeClaim:
+            claimName: redis-pvc
+
+---
+# --- 4. Service: 'redis-service'라는 고정된 내부 주소 생성 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+spec:
+  type: NodePort # 클러스터 내부에서만 접근 가능한 고정 IP 할당
+  selector:
+    app: redis # 'app=redis' 레이블을 가진 Pod를 대상으로 함
+  ports:
+    - port: 6379
+      targetPort: 6379
+      nodePort: 30079 # 외부에서 접근할 포트 (30000-32767 범위 내)

--- a/k8s/dev/infra/redis-deploy.yml
+++ b/k8s/dev/infra/redis-deploy.yml
@@ -55,9 +55,11 @@ spec:
             requests:
               memory: "128Mi"
               cpu: "100m" # 0.1 vCPU
+              ephemeral-storage: "1Gi"
             limits:
               memory: "256Mi"
               cpu: "200m" # 0.2 vCPU
+              ephemeral-storage: "2Gi"
 
           volumeMounts:
             - name: redis-persistent-storage


### PR DESCRIPTION
## 📝 Description

- #️⃣연관된 이슈: https://github.com/f-lab-edu/hotel-reservation-platform/issues/110
- `identity-service`의 기본 인증 시스템 설계를 바탕으로, **로그인, 토큰 재발급, 내 정보 조회** 핵심 API를 구현합니다.
- 모든 인증 로직은 'Stateful JWT' 아키텍처를 기반으로 하며, Redis를 통해 세션을 관리하여 보안과 확장성을 확보했습니다.

## ✨ Key Changes

### 1. 로그인 API (`POST /auth/login`) 구현
- 이메일/비밀번호 검증 후, Access Token과 Refresh Token을 발급합니다.
- Access Token은 `Authorization` 헤더로, Refresh Token은 `HttpOnly` 보안 쿠키로 전달합니다.
- **동시 접속 제어**: Redis의 ZSET과 Hash를 활용하여, 설정된 최대 기기 수를 초과하면 가장 오래된 세션을 자동으로 로그아웃 처리합니다.
    - 이 모든 과정은 **Lua 스크립트**를 통해 **원자적으로 실행**하여 동시성 문제를 해결했습니다.

### 2. 토큰 재발급 API (`GET /auth/refresh`) 구현
- 쿠키에 담긴 Refresh Token을 검증합니다.
- **리프레시 토큰 회전(Rotation)** 전략을 적용하여, 재발급 시 새로운 Access/Refresh 토큰을 모두 발급하고 기존 Refresh Token은 무효화합니다.
- 재발급 시, 최초 로그인 시점(`loginAt`) 정보는 유지하여 세션의 연속성을 관리합니다.

### 3. 내 정보 조회 API (`GET /auth/me`) 및 Argument Resolver 구현
- `@LoginUser` 커스텀 애노테이션과 `LoginUserArgumentResolver`를 구현하여, 컨트롤러가 타입 세이프하게 인증된 사용자 정보를 받을 수 있도록 개선했습니다.
- Argument Resolver는 Access Token의 유효성을 검증할 때, Redis에 저장된 **'활성 토큰 목록'을 조회**하여 로그아웃 등으로 무효화된 토큰을 완벽하게 차단합니다.

### 4. 통합 테스트 (`AuthControllerIntegrationTest`) 작성
- 위 3가지 API의 전체 흐름을 검증하는 `@SpringBootTest` 기반의 통합 테스트를 작성했습니다.
- MockMvc를 사용하여 실제 API 요청을 보내고, 응답 헤더/쿠키 및 Redis의 상태 변화까지 상세하게 검증합니다.

## ❗Note

- 기본 인증 필터는 나머지 Auth API 개발 이후 적용
