### PR TITLE
[ gateway-service ] API 게이트웨이 도입 및 중앙 인증 필터 구현

### DIFF
--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -21,11 +21,26 @@ repositories {
 
 extra["springCloudVersion"] = "2025.0.0"
 
+val jjwtVersion = "0.12.6"
+
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+    implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
+
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-    implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
+    implementation("io.github.oshai:kotlin-logging-jvm:7.0.11")
+
+    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+
+    runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -48,8 +48,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    implementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("io.mockk:mockk:1.14.5")
 }
 
 dependencyManagement {

--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 extra["springCloudVersion"] = "2025.0.0"
 
 val jjwtVersion = "0.12.6"
+val kotestVersion = "5.9.1"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -45,7 +46,10 @@ dependencies {
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }
 
 dependencyManagement {

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/GatewayServiceApplication.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/GatewayServiceApplication.kt
@@ -1,9 +1,11 @@
 package com.msa.gatewayservice
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan(basePackages = ["com.msa.gatewayservice.config.properties"])
 class GatewayServiceApplication
 
 fun main(args: Array<String>) {

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/consts/AuthConstants.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/consts/AuthConstants.kt
@@ -1,0 +1,12 @@
+package com.msa.gatewayservice.auth.consts
+
+
+object AuthConstants {
+    const val AUTH_HEADER_PREFIX = "Bearer "
+    const val CONTEXT_NOT_FOUND_MESSAGE = "인증 정보가 존재하지 않습니다."
+
+
+    private const val ACTIVE_JTI_KEY_PREFIX = "active_jti"
+
+    fun getActiveJtiKey(jti: String) = "$ACTIVE_JTI_KEY_PREFIX:$jti"
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/token/JwtTokenDecoder.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/token/JwtTokenDecoder.kt
@@ -1,0 +1,66 @@
+package com.msa.gatewayservice.auth.token
+
+import com.msa.gatewayservice.auth.token.dto.TokenAuthInfo
+import com.msa.gatewayservice.config.properties.JwtProperties
+import com.msa.gatewayservice.exception.BusinessErrorCode
+import com.msa.identityservice.auth.token.enums.Role
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class JwtTokenDecoder(
+    private val jwtProperties: JwtProperties
+) {
+
+    private fun getClaims(token: String): Claims {
+        val key = Keys.hmacShaKeyFor(jwtProperties.secretKey.toByteArray(StandardCharsets.UTF_8))
+
+        return Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .payload
+    }
+
+    fun extractAuthInfo(token: String): TokenAuthInfo {
+        try {
+            val claims = getClaims(token)
+
+            return extractAuthInfo(claims)
+        } catch (e: Exception) {
+            logger.error { "Extract AuthInfo exception (token): $e" }
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")
+        }
+    }
+
+    private fun extractAuthInfo(claims: Claims): TokenAuthInfo {
+        try {
+            val jti = claims.id
+            val userId = claims.subject.toLong()
+            val role = claims.get("role", String::class.java)
+            val email = claims.get("email", String::class.java)
+            val expiration = claims.expiration
+            val deviceId = claims.get("deviceId", String::class.java)
+
+            return TokenAuthInfo(
+                jti = jti,
+                userId = userId,
+                email = email,
+                role = Role.valueOf(role),
+                expiresAt = expiration,
+                deviceId = deviceId
+            )
+        } catch (e: Exception) {
+            logger.error { "Extract AuthInfo exception (Claims): $e" }
+            throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")
+        }
+    }
+
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/token/dto/TokenAuthInfo.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/token/dto/TokenAuthInfo.kt
@@ -1,0 +1,14 @@
+package com.msa.gatewayservice.auth.token.dto
+
+import com.msa.identityservice.auth.token.enums.Role
+import java.util.*
+
+
+data class TokenAuthInfo(
+    val jti: String,
+    val userId: Long,
+    val role: Role,
+    val email: String,
+    val deviceId: String,
+    val expiresAt: Date,
+)

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/token/enums/Role.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/auth/token/enums/Role.kt
@@ -1,0 +1,7 @@
+package com.msa.identityservice.auth.token.enums
+
+enum class Role {
+    MEMBER, // 일반 사용자
+    HOST,   // 숙소 관리자
+    ADMIN   // 플랫폼 관리자
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/RedisConfig.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/RedisConfig.kt
@@ -1,0 +1,41 @@
+package com.msa.gatewayservice.config
+
+import com.msa.gatewayservice.config.properties.RedisProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+
+@Configuration
+class RedisConfig(
+    private val redisProperties: RedisProperties
+) {
+
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory {
+        val redisHost = redisProperties.host
+        val redisPort = redisProperties.port
+        val redisPassword = redisProperties.password
+
+        val redisStandaloneConfiguration = RedisStandaloneConfiguration(redisHost, redisPort)
+        redisStandaloneConfiguration.setPassword(redisPassword)
+
+        return LettuceConnectionFactory(redisStandaloneConfiguration)
+    }
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        val redisTemplate = RedisTemplate<String, Any>()
+        redisTemplate.connectionFactory = redisConnectionFactory()
+
+        // Key는 String, Value는 모든 객체를 저장할 수 있도록 설정
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = StringRedisSerializer()
+
+        return redisTemplate
+    }
+    
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/SecurityConfig.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/SecurityConfig.kt
@@ -1,0 +1,23 @@
+package com.msa.gatewayservice.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.web.server.SecurityWebFilterChain
+
+@Configuration
+@EnableWebFluxSecurity
+class SecurityConfig {
+
+    @Bean
+    fun securityWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+        return http
+            .csrf { it.disable() }
+            .formLogin { it.disable() }
+            .httpBasic { it.disable() }
+            .authorizeExchange { it.anyExchange().permitAll() }
+            .build()
+    }
+
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/properties/JwtProperties.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/properties/JwtProperties.kt
@@ -1,0 +1,13 @@
+package com.msa.gatewayservice.config.properties
+
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+
+@Validated
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    @field:NotBlank(message = "jwt 시크릿 키가 비어있을 수 없습니다.")
+    val secretKey: String,
+)

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/properties/RedisProperties.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/config/properties/RedisProperties.kt
@@ -1,0 +1,21 @@
+package com.msa.gatewayservice.config.properties
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+@Validated
+@ConfigurationProperties(prefix = "spring.data.redis")
+data class RedisProperties(
+    @field:NotBlank(message = "redis host가 비어있을 수 없습니다.")
+    val host: String,
+
+    @field:Min(6000, message = "redis port는 최소 6000 이상이어야 합니다.")
+    @field:Max(32000, message = "redis port는 최대 32000 넘을 수 없습니다.")
+    val port: Int,
+
+    @field:NotBlank(message = "redis password가 비어있을 수 없습니다.")
+    val password: String,
+)

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/exception/BusinessErrorCode.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/exception/BusinessErrorCode.kt
@@ -1,0 +1,23 @@
+package com.msa.gatewayservice.exception
+
+import org.springframework.http.HttpStatus
+
+
+enum class BusinessErrorCode(
+    val httpStatus: HttpStatus,
+    val defaultMessage: String
+) {
+
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했거나, 요청 값이 잘못되었습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했거나, 요청 값이 잘못되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나, 인증에 실패했습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, "이미 존재하거나, 처리된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+
+    fun exception(message: String?): BusinessException {
+        return BusinessException(this, message ?: defaultMessage)
+    }
+
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/exception/BusinessException.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/exception/BusinessException.kt
@@ -1,0 +1,15 @@
+package com.msa.gatewayservice.exception
+
+import org.springframework.http.HttpStatus
+
+
+class BusinessException(
+    val errorCode: BusinessErrorCode,
+    override val message: String
+) : RuntimeException(message) {
+
+    fun httpStatus(): HttpStatus {
+        return errorCode.httpStatus
+    }
+
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/exception/GlobalExceptionHandler.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/exception/GlobalExceptionHandler.kt
@@ -1,17 +1,15 @@
-package com.msa.identityservice.exception
+package com.msa.gatewayservice.exception
 
-import com.msa.identityservice.support.response.ApiResponse
+import com.msa.gatewayservice.support.response.ApiResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.FieldError
-import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import org.springframework.web.servlet.NoHandlerFoundException
-import org.springframework.web.servlet.resource.NoResourceFoundException
+import org.springframework.web.reactive.resource.NoResourceFoundException
 import java.util.stream.Collectors
 
 
@@ -20,11 +18,7 @@ private val logger = KotlinLogging.logger {}
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
-    @ExceptionHandler(
-        NoHandlerFoundException::class,
-        NoResourceFoundException::class,
-        HttpRequestMethodNotSupportedException::class
-    )
+    @ExceptionHandler(NoResourceFoundException::class)
     fun handleNotFound(exception: Exception): ResponseEntity<ApiResponse<Nothing>> {
         logger.error { exception }
 
@@ -102,7 +96,7 @@ class GlobalExceptionHandler {
     }
 
     companion object {
-        private const val NOT_FOUND_ERROR_MESSAGE = "지원하지 않는 API 유형입니다"
+        private const val NOT_FOUND_ERROR_MESSAGE = "존재하지 않는 URL입니다"
         private const val DEFAULT_ERROR_MESSAGE = "서버 내부 오류로 인한 작업 실패"
     }
 

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/filters/AuthenticationGatewayFilterFactory.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/filters/AuthenticationGatewayFilterFactory.kt
@@ -1,0 +1,61 @@
+package com.msa.gatewayservice.filters
+
+import com.msa.gatewayservice.auth.consts.AuthConstants.AUTH_HEADER_PREFIX
+import com.msa.gatewayservice.auth.consts.AuthConstants.CONTEXT_NOT_FOUND_MESSAGE
+import com.msa.gatewayservice.auth.consts.AuthConstants.getActiveJtiKey
+import com.msa.gatewayservice.auth.token.JwtTokenDecoder
+import com.msa.gatewayservice.exception.BusinessErrorCode
+import org.springframework.cloud.gateway.filter.GatewayFilter
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.http.HttpHeaders
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.stereotype.Component
+
+
+@Component
+class AuthenticationGatewayFilterFactory(
+    private val jwtTokenDecoder: JwtTokenDecoder,
+    private val redisTemplate: RedisTemplate<String, String>
+) : AbstractGatewayFilterFactory<AuthenticationGatewayFilterFactory.Config>(Config::class.java) {
+
+    class Config
+
+    override fun apply(config: Config): GatewayFilter {
+        return GatewayFilter { exchange, chain ->
+            // 1. 헤더에서 Authorization 토큰 가져오기
+            val token = getAccessToken(exchange.request)
+
+            // 2. 토큰 검증
+            val tokenAuthInfo = jwtTokenDecoder.extractAuthInfo(token) // 만료되거나 위변조 시 예외 발생
+
+            // 3. 활성 토큰이 맞는지 확인
+            val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
+            val storedUserId = redisTemplate.opsForValue().get(activeJtiKey)
+            if (storedUserId == null || storedUserId != tokenAuthInfo.userId.toString()) {
+                throw BusinessErrorCode.UNAUTHORIZED.exception("인증 정보가 유효하지 않습니다")
+            }
+
+            // 4. 검증 성공 시, 요청 헤더에 사용자 정보 추가
+            val mutatedRequest = exchange.request.mutate()
+                .header("X-User-Id", tokenAuthInfo.userId.toString())
+                .header("X-User-Role", tokenAuthInfo.role.name)
+                .header("X-User-Email", tokenAuthInfo.email)
+                .build()
+
+            val mutatedExchange = exchange.mutate().request(mutatedRequest).build()
+
+            chain.filter(mutatedExchange)
+        }
+    }
+
+    private fun getAccessToken(request: ServerHttpRequest): String {
+        val headers = request.headers
+        if (!headers.containsKey(HttpHeaders.AUTHORIZATION)) {
+            throw BusinessErrorCode.UNAUTHORIZED.exception(CONTEXT_NOT_FOUND_MESSAGE)
+        }
+
+        return headers[HttpHeaders.AUTHORIZATION]!![0].substring(AUTH_HEADER_PREFIX.length)
+    }
+
+}

--- a/gateway-service/src/main/kotlin/com/msa/gatewayservice/support/response/ApiResponse.kt
+++ b/gateway-service/src/main/kotlin/com/msa/gatewayservice/support/response/ApiResponse.kt
@@ -1,0 +1,36 @@
+package com.msa.gatewayservice.support.response
+
+data class ApiResponse<T>(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: T?
+) {
+
+    companion object {
+        fun <T> create(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "create", message, data)
+        }
+
+        fun <T> read(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "read", message, data)
+        }
+
+        fun <T> update(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "update", message, data)
+        }
+
+        fun <T> delete(message: String, data: T): ApiResponse<T> {
+            return ApiResponse(true, "delete", message, data)
+        }
+
+        fun noContent(message: String): ApiResponse<Nothing> {
+            return ApiResponse(true, "noContent", message, null)
+        }
+
+        fun error(code: String, message: String): ApiResponse<Nothing> {
+            return ApiResponse(false, code, message, null)
+        }
+    }
+
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -1,3 +1,41 @@
+server:
+  port: 8080
+
 spring:
   application:
     name: gateway-service
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:30079}
+      password: ${REDIS_PASSWORD:your-redis-password}
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: identity-service-auth
+              uri: ${IDENTITY_SERVICE_URI:http://localhost:8081}
+              predicates:
+                - Path=/identity-service/auth/**
+              filters:
+                - RewritePath=/identity-service/(?<segment>.*), /$\{segment}
+
+            - id: identity-service-member-create
+              uri: ${IDENTITY_SERVICE_URI:http://localhost:8081}
+              predicates:
+                - Path=/identity-service/member
+                - Method=POST
+              filters:
+                - RewritePath=/identity-service/(?<segment>.*), /$\{segment}
+
+            - id: identity-service
+              uri: ${IDENTITY_SERVICE_URI:http://localhost:8081}
+              predicates:
+                - Path=/identity-service/**
+              filters:
+                - RewritePath=/identity-service/(?<segment>.*), /$\{segment}
+                - Authentication
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY:this-is-a-very-long-and-secure-secret-key-for-hs256-algorithm}

--- a/gateway-service/src/test/kotlin/com/msa/gatewayservice/GatewayServiceIntegrationTest.kt
+++ b/gateway-service/src/test/kotlin/com/msa/gatewayservice/GatewayServiceIntegrationTest.kt
@@ -1,0 +1,110 @@
+package com.msa.gatewayservice
+
+import com.msa.gatewayservice.auth.consts.AuthConstants.getActiveJtiKey
+import com.msa.gatewayservice.auth.token.JwtTokenDecoder
+import com.msa.gatewayservice.auth.token.dto.TokenAuthInfo
+import com.msa.identityservice.auth.token.enums.Role
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.util.*
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class GatewayIntegrationTest(
+    private val webTestClient: WebTestClient,
+    private val jwtTokenDecoder: JwtTokenDecoder,
+    private val redisTemplate: RedisTemplate<String, String>
+) : BehaviorSpec({
+
+    lateinit var mockWebServer: MockWebServer
+
+    beforeSpec {
+        mockWebServer = MockWebServer()
+        mockWebServer.start(8001)
+    }
+
+    afterSpec {
+        mockWebServer.shutdown()
+    }
+
+    Given("Gateway에 공개 경로와 보안 경로가 설정되어 있을 때") {
+
+        When("클라이언트가 인증이 필요 없는 공개 경로(회원가입)로 요청을 보내면") {
+            mockWebServer.enqueue(MockResponse().setResponseCode(201))
+
+            val response = webTestClient.post().uri("/identity-service/members")
+                .exchange()
+
+            Then("인증 필터를 거치지 않고, 요청이 올바르게 전달된다") {
+                response.expectStatus().isCreated
+                mockWebServer.takeRequest().path shouldBe "/members"
+            }
+        }
+
+        When("클라이언트가 유효한 토큰과 함께 보안 경로로 요청을 보내면") {
+            val validToken = "valid-jwt"
+            val mockAuthInfo = TokenAuthInfo(
+                userId = 1L,
+                role = Role.MEMBER,
+                email = "test@test.com",
+                deviceId = "device-1",
+                jti = "jti-1",
+                expiresAt = Date()
+            )
+
+            // JwtTokenProvider Mock 설정
+            every { jwtTokenDecoder.extractAuthInfo(any()) } returns mockAuthInfo
+
+            val activeJtiKey = getActiveJtiKey(mockAuthInfo.jti)
+            redisTemplate.opsForValue().set(activeJtiKey, mockAuthInfo.userId.toString())
+
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+            val response = webTestClient.get().uri("/identity-service/test")
+                .header("Authorization", "Bearer $validToken")
+                .exchange()
+
+            Then("인증 필터를 통과하고, 사용자 정보 헤더가 추가되어 요청이 전달된다") {
+                response.expectStatus().isOk
+                val recordedRequest = mockWebServer.takeRequest()
+                recordedRequest.path shouldBe "/test"
+                recordedRequest.getHeader("X-User-Id") shouldBe "1"
+                recordedRequest.getHeader("X-User-Role") shouldBe "MEMBER"
+                recordedRequest.getHeader("X-User-Email") shouldBe "test@test.com"
+            }
+
+            // 불필요해진 Redis 데이터 삭제
+            redisTemplate.delete(activeJtiKey)
+        }
+
+        When("클라이언트가 토큰 없이 보안 경로로 요청을 보내면") {
+            val response = webTestClient.get().uri("/identity-service/test")
+                .exchange()
+
+            Then("Gateway는 401 Unauthorized 에러를 즉시 반환한다") {
+                response.expectStatus().isUnauthorized
+            }
+        }
+    }
+
+}) {
+    
+    // 테스트 환경에서 실제 JwtTokenProvider 대신 Mock Bean을 사용하도록 설정
+    @TestConfiguration
+    class TestJwtConfig {
+        @Bean
+        fun jwtTokenDecoder(): JwtTokenDecoder = mockk(relaxed = true)
+    }
+
+}

--- a/gateway-service/src/test/resources/application-test.yml
+++ b/gateway-service/src/test/resources/application-test.yml
@@ -1,0 +1,41 @@
+server:
+  port: 8000
+
+spring:
+  application:
+    name: gateway-service
+  data:
+    redis:
+      host: ${REDIS_TEST_HOST:localhost}
+      port: ${REDIS_TEST_PORT:30079}
+      password: ${REDIS_TEST_PASSWORD:your-redis-password}
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: identity-service-auth
+              uri: http://localhost:8001
+              predicates:
+                - Path=/identity-service/auth/**
+              filters:
+                - RewritePath=/identity-service/(?<segment>.*), /$\{segment}
+
+            - id: identity-service-member-create
+              uri: http://localhost:8001
+              predicates:
+                - Path=/identity-service/members
+                - Method=POST
+              filters:
+                - RewritePath=/identity-service/(?<segment>.*), /$\{segment}
+
+            - id: identity-service
+              uri: http://localhost:8001
+              predicates:
+                - Path=/identity-service/**
+              filters:
+                - RewritePath=/identity-service/(?<segment>.*), /$\{segment}
+                - Authentication
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY:this-is-a-very-long-and-secure-secret-key-for-hs256-algorithm}

--- a/identity-service/build.gradle.kts
+++ b/identity-service/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    implementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     jooqGenerator("com.mysql:mysql-connector-j")

--- a/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
@@ -15,7 +15,6 @@ import com.msa.identityservice.auth.token.enums.Role
 import com.msa.identityservice.config.properties.JwtProperties
 import com.msa.identityservice.member.service.MemberService
 import com.msa.identityservice.member.service.dto.RegisterMemberDto
-import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -38,7 +37,6 @@ import java.lang.Thread.sleep
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
-@KotestTestScope
 class AuthControllerIntegrationTest @Autowired constructor(
     private val mockMvc: MockMvc,
     private val objectMapper: ObjectMapper,

--- a/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/auth/AuthControllerIntegrationTest.kt
@@ -13,21 +13,19 @@ import com.msa.identityservice.auth.controller.request.LogoutRequest
 import com.msa.identityservice.auth.token.JwtTokenProvider
 import com.msa.identityservice.auth.token.enums.Role
 import com.msa.identityservice.config.properties.JwtProperties
-import com.msa.identityservice.infrastructure.IdGenerator
-import com.msa.identityservice.jooq.enums.MemberStatus
-import com.msa.identityservice.jooq.tables.pojos.Member
-import com.msa.identityservice.member.repository.MemberRepository
+import com.msa.identityservice.member.service.MemberService
+import com.msa.identityservice.member.service.dto.RegisterMemberDto
+import io.kotest.core.spec.KotestTestScope
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import jakarta.servlet.http.Cookie
-import org.hamcrest.Matchers.containsInAnyOrder
-import org.junit.jupiter.api.BeforeEach
+import org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.MediaType
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
@@ -35,358 +33,340 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.transaction.annotation.Transactional
 import java.lang.Thread.sleep
-import kotlin.test.Test
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
+@KotestTestScope
 class AuthControllerIntegrationTest @Autowired constructor(
     private val mockMvc: MockMvc,
     private val objectMapper: ObjectMapper,
-    private val idGenerator: IdGenerator,
-    private val memberRepository: MemberRepository,
-    private val passwordEncoder: PasswordEncoder,
+    private val memberService: MemberService,
     private val jwtTokenProvider: JwtTokenProvider,
     private val redisTemplate: RedisTemplate<String, String>,
     private val jwtProperties: JwtProperties
-) {
-    lateinit var testMember: Member
-    val testPassword = "testPassword1!"
+) : BehaviorSpec({
 
-    @BeforeEach
-    fun setup() {
-        testMember = Member(
-            id = idGenerator.generate(),
-            email = "test@example.com",
-            password = passwordEncoder.encode(testPassword),
-            status = MemberStatus.ACTIVE,
-        )
-        memberRepository.insert(testMember)
-    }
-
-    @Test
-    fun `정상적인 정보로 로그인 요청 시, 토큰이 발급되고 세션 정보가 Redis에 저장된다`() {
-        // Given
-        val deviceId = "test-device-1"
-        val request = LoginRequest(
-            email = testMember.email,
-            password = testPassword,
-            role = Role.MEMBER,
-            deviceId = deviceId
-        )
-
-        // When
-        val result = mockMvc.post("/auth/login") {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
-        }.andExpect {
-            status { isNoContent() } // 204 No Content
-            header { exists(AUTH_HEADER_NAME) }
-            cookie { exists(REFRESH_COOKIE_NAME) }
-        }.andReturn()
-
-        // Then: Token 검증 및 Redis에 데이터가 올바르게 저장되었는지 직접 검증
-        val accessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
+    fun deleteLoginHistory(accessToken: String) {
         val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
-        tokenAuthInfo.userId shouldBe testMember.id
-        tokenAuthInfo.role shouldBe Role.MEMBER
-        tokenAuthInfo.deviceId shouldBe deviceId
-        tokenAuthInfo.email shouldBe testMember.email
 
-        val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
-        val savedRefreshTokenInfo = redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, deviceId)
-        savedRefreshTokenInfo shouldNotBe null
-
-        val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
-        val savedActiveJtiValue = redisTemplate.opsForValue().get(activeJtiKey)
-        savedActiveJtiValue shouldBe testMember.id.toString()
-
-        // 불필요해진 데이터 삭제
-        deleteLoginHistory(accessToken)
-    }
-
-    private fun deleteLoginHistory(accessToken: String) {
-        val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
+        // 활성 토큰 내역 KEY 삭제
         val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
         redisTemplate.delete(activeJtiKey)
+
+        // 리프레쉬 토큰 정보 HASH 삭제
         val userRefreshTokensKey = getRefreshTokenKey(tokenAuthInfo.role, tokenAuthInfo.userId)
         redisTemplate.opsForHash<String, String>().delete(userRefreshTokensKey, tokenAuthInfo.deviceId)
+
+        // 리프레쉬 토큰 세션 만료 ZSET 내역 삭제
         val sessionKey = getSessionKey(tokenAuthInfo.role, tokenAuthInfo.userId)
         redisTemplate.opsForZSet().remove(sessionKey, tokenAuthInfo.deviceId)
     }
 
-    @Test
-    fun `최대 접속 기기 수를 초과하여 로그인 시, 가장 오래된 세션이 자동 로그아웃된다`() {
-        // Given: 최대 접속 기기 수만큼 미리 로그인을 수행해 둠
-        val maxDevices = jwtProperties.maxDeviceCount
-        val accessTokenList = mutableListOf<String>()
-        for (i in 1..maxDevices) {
-            sleep(100)
-            accessTokenList.add(performLoginAndGetTokens("device-$i").first)
-        }
-
-        val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
-        redisTemplate.opsForHash<String, String>().size(userRefreshTokensKey) shouldBe maxDevices
-
-        // When: 새로운 기기(최대 수를 초과하는)가 로그인을 시도
-        val newDeviceId = "device-${maxDevices + 1}"
-        val request = LoginRequest(testMember.email, testPassword, Role.MEMBER, newDeviceId)
-
-        val result = mockMvc.post("/auth/login") {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
-        }.andExpect {
-            status { isNoContent() } // 로그인은 성공해야 함
-        }.andReturn()
-
-        // Then: Redis 상태를 검증
-        // 1. 전체 세션 수는 여전히 최대 기기 수와 같아야 함
-        redisTemplate.opsForHash<String, String>().size(userRefreshTokensKey) shouldBe maxDevices
-        // 2. 가장 오래된 세션(device-1)은 삭제되어야 함
-        redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, "device-1") shouldBe null
-        // 3. 새로 로그인한 세션(newDeviceId)은 존재해야 함
-        redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, newDeviceId) shouldNotBe null
-
-        // 불필요해진 데이터 삭제
-        accessTokenList.forEach { accessToken -> deleteLoginHistory(accessToken) }
-        val accessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
-        deleteLoginHistory(accessToken)
+    fun performLogin(loginRequest: LoginRequest) = mockMvc.post("/auth/login") {
+        contentType = MediaType.APPLICATION_JSON
+        content = objectMapper.writeValueAsString(loginRequest)
     }
 
-    // 테스트 코드 중복을 줄이기 위한 헬퍼 함수
-    private fun performLoginAndGetTokens(deviceId: String): Pair<String, Cookie> {
-        val result = performLogin(deviceId).andReturn()
+    fun performLoginAndGetTokens(loginRequest: LoginRequest): Pair<String, Cookie> {
+        val result = performLogin(loginRequest).andReturn()
         val accessToken = result.response.getHeader("Authorization")!!.substring(7)
         val refreshTokenCookie = result.response.getCookie("refreshToken")!!
         return Pair(accessToken, refreshTokenCookie)
     }
 
-    private fun performLogin(deviceId: String) = mockMvc.post("/auth/login") {
-        contentType = MediaType.APPLICATION_JSON
-        content = objectMapper.writeValueAsString(
-            LoginRequest(testMember.email, testPassword, Role.MEMBER, deviceId)
+    fun createLoginRequest(registerMemberDto: RegisterMemberDto, deviceId: String) = LoginRequest(
+        email = registerMemberDto.email,
+        password = registerMemberDto.password,
+        role = Role.MEMBER,
+        deviceId = deviceId
+    )
+
+    Given("가입된 멤버 및 로그인 디바이스 정보") {
+        val registerMemberDto = RegisterMemberDto(
+            email = "test@email.com",
+            password = "test1234!",
+            phoneNumber = "010-9999-9999"
         )
-    }
+        val testMember = memberService.register(registerMemberDto)
+        val loginDeviceId = "test-device-1"
 
+        When("동시 접속 기기가 없을 경우의 로그인 요청") {
+            val request = createLoginRequest(registerMemberDto, loginDeviceId)
 
-    @Test
-    fun `유효한 리프레시 토큰으로 토큰 재발급 요청 시, 새로운 토큰들이 발급된다`() {
-        // Given: 먼저 로그인을 수행하여 유효한 토큰들을 발급받음
-        val deviceId = "test-device-2"
-        val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(deviceId)
+            val result = mockMvc.post("/auth/login") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isNoContent() } // 204 No Content
+                header { exists(AUTH_HEADER_NAME) }
+                cookie { exists(REFRESH_COOKIE_NAME) }
+            }.andReturn()
 
-        // When
-        val result = mockMvc.get("/auth/refresh") {
-            cookie(refreshTokenCookie)
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken)) // 재발급 시에도 만료된 AccessToken은 보내야 함
-        }.andExpect {
-            status { isNoContent() }
-        }.andReturn()
+            Then("인증 토큰 발급 및 활성 토큰 정보 Redis 저장") {
+                val accessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
+                val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
+                tokenAuthInfo.userId shouldBe testMember.id
+                tokenAuthInfo.role shouldBe Role.MEMBER
+                tokenAuthInfo.deviceId shouldBe loginDeviceId
+                tokenAuthInfo.email shouldBe testMember.email
 
-        // Then
-        val newAccessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
-        val newRefreshTokenCookie = result.response.getCookie(REFRESH_COOKIE_NAME)
+                val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
+                val savedRefreshTokenInfo =
+                    redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, loginDeviceId)
+                savedRefreshTokenInfo shouldNotBe null
 
-        newAccessToken shouldNotBe accessToken
-        newRefreshTokenCookie?.value shouldNotBe refreshTokenCookie.value
+                val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
+                val savedActiveJtiValue = redisTemplate.opsForValue().get(activeJtiKey)
+                savedActiveJtiValue shouldBe testMember.id.toString()
 
-        // 불필요해진 데이터 삭제
-        deleteLoginHistory(newAccessToken)
-    }
-
-    @Test
-    fun `유효하지 않은(위변조된) 리프레시 토큰으로 재발급 요청 시, 401 에러를 반환한다`() {
-        // Given
-        val deviceId = "test-device-4"
-        val (accessToken, _) = performLoginAndGetTokens(deviceId)
-
-        // 위변조된 가짜 리프레시 토큰 생성
-        val fakeRefreshTokenCookie = Cookie("refreshToken", "this.is.fake-token")
-
-        // When & Then
-        mockMvc.get("/auth/refresh") {
-            cookie(fakeRefreshTokenCookie)
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken))
-        }.andExpect {
-            status { isUnauthorized() } // 401 Unauthorized
-        }
-
-        // 불필요해진 데이터 삭제
-        deleteLoginHistory(accessToken)
-    }
-
-    @Test
-    fun `이미 사용된(회전된) 리프레시 토큰으로 재발급 요청 시, 401 에러를 반환한다`() {
-        // Given
-        val deviceId = "test-device-5"
-        // 1. 최초 로그인
-        val (accessToken_A, refreshTokenCookie_A) = performLoginAndGetTokens(deviceId)
-
-        // 2. 정상적인 토큰 재발급. 이 시점에 refreshToken_A는 무효화됨.
-        val result = mockMvc.get("/auth/refresh") {
-            cookie(refreshTokenCookie_A)
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken_A))
-        }.andExpect {
-            status { isNoContent() }
-        }.andReturn()
-
-        // When: 이전에 사용했던 refreshToken_A로 다시 재발급을 시도 (Replay Attack)
-        mockMvc.get("/auth/refresh") {
-            cookie(refreshTokenCookie_A)
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken_A))
-        }.andExpect {
-            // Then: 401 에러가 발생해야 함
-            status { isUnauthorized() }
-        }
-
-        // 불필요해진 데이터 삭제
-        val accessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
-        deleteLoginHistory(accessToken)
-    }
-
-    @Test
-    fun `유효한 액세스 토큰으로 내 정보 조회 요청 시, 사용자 정보가 반환된다`() {
-        // Given
-        val deviceId = "test-device-3"
-        val (accessToken, _) = performLoginAndGetTokens(deviceId)
-
-        // When & Then
-        mockMvc.get("/auth/me") {
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken))
-        }.andExpect {
-            status { isOk() }
-            jsonPath("$.success") { value(true) }
-            jsonPath("$.data.userId") { value(testMember.id) }
-            jsonPath("$.data.email") { value(testMember.email) }
-            jsonPath("$.data.role") { value(Role.MEMBER.name) }
-            jsonPath("$.data.deviceId") { value(deviceId) }
-        }
-
-        // 불필요해진 데이터 삭제
-        deleteLoginHistory(accessToken)
-    }
-
-    @Test
-    fun `로그인된 사용자가 자신의 활성 세션 목록을 조회할 수 있다`() {
-        // Given: 여러 기기에서 로그인하여 2개의 세션을 생성
-        val deviceIdA = "test-device-A"
-        val deviceIdB = "test-device-B"
-        val (accessTokenFromA, _) = performLoginAndGetTokens(deviceIdA)
-        val (accessTokenFromB, _) = performLoginAndGetTokens(deviceIdB)
-
-        // When & Then
-        mockMvc.get("/auth/sessions") {
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessTokenFromB))
-        }.andExpect {
-            status { isOk() }
-            jsonPath("$.success") { value(true) }
-            // 응답된 세션 목록의 개수가 2개인지 확인
-            jsonPath("$.data.sessions.length()") { value(2) }
-            // 응답된 세션 목록에 device-A와 device-B가 모두 포함되어 있는지 확인 (순서 무관)
-            jsonPath("$.data.sessions[*].deviceId", containsInAnyOrder(deviceIdA, deviceIdB))
-        }
-
-        // 불필요해진 데이터 삭제
-        deleteLoginHistory(accessTokenFromA)
-        deleteLoginHistory(accessTokenFromB)
-    }
-
-    @Test
-    fun `현재 기기 로그아웃 요청 시, 해당 세션 정보가 삭제되고 쿠키가 초기화된다`() {
-        // Given: 'device-A'로 로그인하여 세션을 생성
-        val deviceId = "device-A"
-        val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(deviceId)
-        val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
-        val userRefreshTokensKey = getRefreshTokenKey(tokenAuthInfo.role, tokenAuthInfo.userId)
-        val userSessionAgesKey = getSessionKey(tokenAuthInfo.role, tokenAuthInfo.userId)
-
-        // 로그인 직후 Redis에 세션 정보가 있는지 확인
-        redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, tokenAuthInfo.deviceId) shouldNotBe null
-        redisTemplate.opsForZSet().score(userSessionAgesKey, tokenAuthInfo.deviceId) shouldNotBe null
-
-        // When
-        mockMvc.delete("/auth/logout") {
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken))
-            cookie(refreshTokenCookie) // 로그아웃 시에도 본인 확인을 위해 쿠키는 필요
-        }.andExpect {
-            // Then
-            status { isOk() }
-            // 쿠키가 삭제되었는지 확인 (Max-Age=0)
-            cookie {
-                maxAge(REFRESH_COOKIE_NAME, 0)
+                // 불필요한 Redis 데이터 삭제
+                deleteLoginHistory(accessToken)
             }
         }
 
-        // Then 2: Redis에서 세션 정보가 모두 삭제되었는지 검증
-        val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
-        redisTemplate.opsForValue().get(activeJtiKey) shouldBe null
-        redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, tokenAuthInfo.deviceId) shouldBe null
-        redisTemplate.opsForZSet().score(userSessionAgesKey, tokenAuthInfo.deviceId) shouldBe null
+        When("최대 접속 기기까지 로그인 상태일 때 로그인 요청") {
+            val maxDeviceCount = jwtProperties.maxDeviceCount
+            val accessTokenList = mutableListOf<String>()
+            for (i in 1..maxDeviceCount) {
+                sleep(100)
+                val loginRequest = createLoginRequest(registerMemberDto, "device-$i")
+                val (accessToken, _) = performLoginAndGetTokens(loginRequest)
+                accessTokenList.add(accessToken)
+            }
+
+            val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
+            redisTemplate.opsForHash<String, String>().size(userRefreshTokensKey) shouldBe maxDeviceCount
+
+            val newDeviceId = "device-${maxDeviceCount + 1}"
+            val request = createLoginRequest(registerMemberDto, newDeviceId)
+
+            val result = mockMvc.post("/auth/login") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isNoContent() } // 로그인은 성공해야 함
+            }.andReturn()
+
+            Then("제일 오래전에 접속한 기기 세션 자동 로그아웃") {
+                // 1. 전체 세션 수는 여전히 최대 기기 수와 같아야 함
+                redisTemplate.opsForHash<String, String>().size(userRefreshTokensKey) shouldBe maxDeviceCount
+                // 2. 가장 오래된 세션(device-1)은 삭제되어야 함
+                redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, "device-1") shouldBe null
+                // 3. 새로 로그인한 세션(newDeviceId)은 존재해야 함
+                redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, newDeviceId) shouldNotBe null
+
+                // 불필요해진 데이터 삭제
+                accessTokenList.forEach { accessToken -> deleteLoginHistory(accessToken) }
+                val accessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
+                deleteLoginHistory(accessToken)
+            }
+        }
+
+        When("유효한 리프레시 토큰으로 토큰 재발급 요청") {
+            val loginRequest = createLoginRequest(registerMemberDto, loginDeviceId)
+            val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest)
+
+            val result = mockMvc.get("/auth/refresh") {
+                cookie(refreshTokenCookie)
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken)) // 재발급 시에도 AccessToken 확인
+            }.andExpect {
+                status { isNoContent() }
+            }.andReturn()
+
+            Then("새로운 토큰 발급 확인") {
+                val newAccessToken = result.response.getHeader(AUTH_HEADER_NAME)!!.substring(AUTH_HEADER_PREFIX.length)
+                val newRefreshTokenCookie = result.response.getCookie(REFRESH_COOKIE_NAME)
+
+                newAccessToken shouldNotBe accessToken
+                newRefreshTokenCookie?.value shouldNotBe refreshTokenCookie.value
+
+                // 불필요해진 데이터 삭제
+                deleteLoginHistory(newAccessToken)
+            }
+        }
+
+        When("유효하지 않은(위변조된) 리프레시 토큰으로 재발급 요청") {
+            val loginRequest = createLoginRequest(registerMemberDto, loginDeviceId)
+            val (accessToken, _) = performLoginAndGetTokens(loginRequest)
+            // 위변조된 가짜 리프레시 토큰 생성
+            val fakeRefreshTokenCookie = Cookie("refreshToken", "this.is.fake-token")
+
+            val result = mockMvc.get("/auth/refresh") {
+                cookie(fakeRefreshTokenCookie)
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken))
+            }.andExpect {
+                status { isUnauthorized() } // 401 Unauthorized
+            }.andReturn()
+
+            Then("올바르지 않는 인증 정보인 점을 응답") {
+                val responseBody = objectMapper.readTree(result.response.contentAsString)
+                val message = responseBody.get("message").asText()
+                message shouldBe "인증 정보가 올바르지 않습니다."
+
+                // 불필요해진 데이터 삭제
+                deleteLoginHistory(accessToken)
+            }
+        }
+
+        When("유효한 인증 토큰으로 내 정보 조회 요청") {
+            val loginRequest = createLoginRequest(registerMemberDto, loginDeviceId)
+            val (accessToken, _) = performLoginAndGetTokens(loginRequest)
+
+            val result = mockMvc.get("/auth/me") {
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.userId") { value(testMember.id) }
+                jsonPath("$.data.email") { value(testMember.email) }
+                jsonPath("$.data.role") { value(Role.MEMBER.name) }
+                jsonPath("$.data.deviceId") { value(loginRequest.deviceId) }
+            }.andReturn()
+
+            Then("기본 로그인 사용자 정보가 반환") {
+                val responseBody = objectMapper.readTree(result.response.contentAsString)
+                val userId = responseBody.get("data").get("userId").asLong()
+                userId shouldBe testMember.id
+                val email = responseBody.get("data").get("email").asText()
+                email shouldBe testMember.email
+                val deviceId = responseBody.get("data").get("deviceId").asText()
+                deviceId shouldBe loginDeviceId
+
+                // 불필요해진 데이터 삭제
+                deleteLoginHistory(accessToken)
+            }
+        }
+
+        When("로그인된 사용자가 자신의 활성 세션 목록 요청") {
+            val deviceIdA = "Device-A"
+            val loginRequestFromA = createLoginRequest(registerMemberDto, deviceIdA)
+            val (accessTokenFromA, _) = performLoginAndGetTokens(loginRequestFromA)
+
+            val deviceIdB = "Device-B"
+            val loginRequestFromB = createLoginRequest(registerMemberDto, deviceIdB)
+            val (accessTokenFromB, _) = performLoginAndGetTokens(loginRequestFromB)
+
+            val result = mockMvc.get("/auth/sessions") {
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessTokenFromB))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+            }.andReturn()
+
+            Then("세션 응답 정보에 접속 중인 기기 정보 포함") {
+                val responseBody = objectMapper.readTree(result.response.contentAsString)
+                val deviceIds = responseBody.get("data").get("sessions").findValuesAsText("deviceId")
+                deviceIds.size shouldBe 2
+                deviceIds.contains(deviceIdA) shouldBe true
+                deviceIds.contains(deviceIdB) shouldBe true
+
+                // 불필요해진 데이터 삭제
+                deleteLoginHistory(accessTokenFromA)
+                deleteLoginHistory(accessTokenFromB)
+            }
+        }
+
+        When("로그인된 사용자가 로그아웃 요청") {
+            val loginRequest = createLoginRequest(registerMemberDto, loginDeviceId)
+            val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest)
+
+            val result = mockMvc.delete("/auth/logout") {
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessToken))
+                cookie(refreshTokenCookie) // 로그아웃 시에도 본인 확인을 위해 쿠키는 필요
+            }.andExpect {
+                // Then
+                status { isOk() }
+                // 쿠키가 삭제되었는지 확인 (Max-Age=0)
+                cookie {
+                    maxAge(REFRESH_COOKIE_NAME, 0)
+                }
+            }.andReturn()
+
+            Then("기존 인증 토큰이 무효화되기 위해 Redis 로그인 세션 정보가 삭제됨") {
+                val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
+                val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
+                redisTemplate.opsForValue().get(activeJtiKey) shouldBe null
+
+                val userRefreshTokensKey = getRefreshTokenKey(tokenAuthInfo.role, tokenAuthInfo.userId)
+                redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, loginDeviceId) shouldBe null
+
+                val userSessionAgesKey = getSessionKey(tokenAuthInfo.role, tokenAuthInfo.userId)
+                redisTemplate.opsForZSet().score(userSessionAgesKey, loginDeviceId) shouldBe null
+            }
+        }
+
+        When("다른 기기 원격 로그아웃 요청 시") {
+            val deviceIdA = "Device-A"
+            val loginRequestFromA = createLoginRequest(registerMemberDto, deviceIdA)
+            val (accessTokenFromA, _) = performLoginAndGetTokens(loginRequestFromA)
+
+            val deviceIdB = "Device-B"
+            val loginRequestFromB = createLoginRequest(registerMemberDto, deviceIdB)
+            val (accessTokenFromB, _) = performLoginAndGetTokens(loginRequestFromB)
+
+            val request = LogoutRequest(deviceId = deviceIdA)
+            mockMvc.delete("/auth/logout-device") {
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessTokenFromB))
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isOk() }
+            }
+
+            Then("지정된 기기의 로그인 세션만 삭제된다") {
+                // 1. 로그아웃된 device-A의 세션은 삭제되어야 함
+                val tokenAuthInfoA = jwtTokenProvider.extractAuthInfo(accessTokenFromA)
+                val activeJtiKeyA = getActiveJtiKey(tokenAuthInfoA.jti)
+                redisTemplate.opsForValue().get(activeJtiKeyA) shouldBe null
+
+                val userRefreshTokensKey = getRefreshTokenKey(tokenAuthInfoA.role, tokenAuthInfoA.userId)
+                redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, deviceIdA) shouldBe null
+
+                val userSessionAgesKey = getSessionKey(tokenAuthInfoA.role, tokenAuthInfoA.userId)
+                redisTemplate.opsForZSet().score(userSessionAgesKey, deviceIdA) shouldBe null
+
+                // 2. 요청을 보낸 device-B의 세션은 그대로 남아있어야 함
+                redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, deviceIdB) shouldNotBe null
+
+                // 불필요해진 데이터 삭제
+                deleteLoginHistory(accessTokenFromB)
+            }
+        }
+
+        When("모든 기기 로그아웃 요청 시") {
+            // 3개의 기기로 로그인 접속
+            val deviceIds = listOf("device-1", "device-2", "device-3")
+            val accessTokenList = mutableListOf<String>()
+            deviceIds.forEach { deviceId ->
+                val loginRequest = createLoginRequest(registerMemberDto, deviceId)
+                val (accessToken, _) = performLoginAndGetTokens(loginRequest)
+                accessTokenList.add(accessToken)
+            }
+
+            // When
+            mockMvc.delete("/auth/logout-all") {
+                header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessTokenList.first()))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.logoutInfos.length()") { value(3) }
+                jsonPath("$.data.logoutInfos[*].deviceId", containsInAnyOrder("device-1", "device-2", "device-3"))
+            }
+            Then("해당 유저의 모든 로그인 세션 정보가 삭제된다") {
+                val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
+                val userSessionAgesKey = getSessionKey(Role.MEMBER, testMember.id)
+                redisTemplate.hasKey(userRefreshTokensKey) shouldBe false
+                redisTemplate.hasKey(userSessionAgesKey) shouldBe false
+                accessTokenList.forEach { accessToken ->
+                    val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
+                    val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
+                    redisTemplate.opsForValue().get(activeJtiKey) shouldBe null
+                }
+            }
+        }
     }
 
-    @Test
-    fun `다른 기기 원격 로그아웃 요청 시, 지정된 기기의 세션만 삭제된다`() {
-        // Given: device-A와 device-B, 두 개의 세션을 생성
-        val deviceIdToLogout = "device-A"
-        performLogin(deviceIdToLogout)
+})
 
-        val actingDeviceId = "device-B"
-        val (accessTokenFromB, _) = performLoginAndGetTokens(actingDeviceId)
-
-        val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
-
-        // When: device-B에서 device-A를 로그아웃 시킴
-        val request = LogoutRequest(deviceId = deviceIdToLogout)
-        mockMvc.delete("/auth/logout-device") {
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessTokenFromB))
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
-        }.andExpect {
-            status { isOk() }
-            jsonPath("$.data.deviceId") { value(deviceIdToLogout) }
-        }
-
-        // Then: Redis 상태를 검증
-        // 1. 로그아웃된 device-A의 세션은 삭제되어야 함
-        redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, deviceIdToLogout) shouldBe null
-        // 2. 요청을 보낸 device-B의 세션은 그대로 남아있어야 함
-        redisTemplate.opsForHash<String, String>().get(userRefreshTokensKey, actingDeviceId) shouldNotBe null
-
-        // 불필요해진 데이터 삭제
-        deleteLoginHistory(accessTokenFromB)
-    }
-
-    @Test
-    fun `모든 기기 로그아웃 요청 시, 해당 유저의 모든 세션 정보가 삭제된다`() {
-        // Given: 3개의 다른 기기에서 로그인
-        val deviceIds = listOf("device-1", "device-2", "device-3")
-        val accessTokenList = mutableListOf<String>()
-        deviceIds.forEach { deviceId ->
-            val (accessToken, _) = performLoginAndGetTokens(deviceId)
-            accessTokenList.add(accessToken)
-        }
-        val userRefreshTokensKey = getRefreshTokenKey(Role.MEMBER, testMember.id)
-        val userSessionAgesKey = getSessionKey(Role.MEMBER, testMember.id)
-        redisTemplate.opsForHash<String, String>().size(userRefreshTokensKey) shouldBe 3
-
-        // When
-        mockMvc.delete("/auth/logout-all") {
-            header(AUTH_HEADER_NAME, getAccessTokenHeaderValue(accessTokenList.first()))
-        }.andExpect {
-            status { isOk() }
-            jsonPath("$.success") { value(true) }
-            jsonPath("$.data.logoutInfos.length()") { value(3) }
-            jsonPath("$.data.logoutInfos[*].deviceId", containsInAnyOrder("device-1", "device-2", "device-3"))
-        }
-
-        // Then: Redis의 모든 관련 키가 삭제되었는지 확인
-        redisTemplate.hasKey(userRefreshTokensKey) shouldBe false
-        redisTemplate.hasKey(userSessionAgesKey) shouldBe false
-        accessTokenList.forEach { accessToken ->
-            val tokenAuthInfo = jwtTokenProvider.extractAuthInfo(accessToken)
-            val activeJtiKey = getActiveJtiKey(tokenAuthInfo.jti)
-            redisTemplate.hasKey(activeJtiKey) shouldBe false
-        }
-    }
-}

--- a/identity-service/src/test/kotlin/com/msa/identityservice/config/TestConfig.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/config/TestConfig.kt
@@ -1,0 +1,12 @@
+package com.msa.identityservice.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+
+
+class TestConfig : AbstractProjectConfig() {
+
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+}

--- a/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
@@ -3,12 +3,12 @@ package com.msa.identityservice.member
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.msa.identityservice.exception.BusinessErrorCode
 import com.msa.identityservice.jooq.enums.MemberStatus
-import com.msa.identityservice.jooq.tables.pojos.Member
 import com.msa.identityservice.member.controller.request.MemberRegistrationRequest
 import com.msa.identityservice.member.repository.MemberRepository
+import io.kotest.core.spec.KotestTestScope
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -18,81 +18,67 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @SpringBootTest
 @AutoConfigureMockMvc // MockMvc를 실제 서버처럼 사용하기 위한 설정
 @ActiveProfiles("test")
 @Transactional
+@KotestTestScope
 class MemberControllerIntegrationTest @Autowired constructor(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-    private val memberRepository: MemberRepository, // DB 상태 검증을 위해 실제 Repository 주입
-    private val passwordEncoder: PasswordEncoder
-) {
+    val mockMvc: MockMvc,
+    val objectMapper: ObjectMapper,
+    val memberRepository: MemberRepository,
+    val passwordEncoder: PasswordEncoder,
+) : BehaviorSpec({
 
-    @Test
-    fun `회원 가입에 성공하고, 데이터베이스에 암호화된 비밀번호로 저장된다`() {
-        // Given
+    Given("신규 멤버 정보") {
         val request = MemberRegistrationRequest(
-            email = "test@example.com",
+            email = "${UUID.randomUUID()}@example.com",
             password = "Password123!",
             phoneNumber = "010-1234-5678"
         )
 
-        // When
-        val result = mockMvc.post("/members") {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
-        }.andExpect {
-            status { isCreated() } // 201 Created 상태인지 확인
-            jsonPath("$.success") { value(true) }
-            jsonPath("$.code") { value("create") }
-            jsonPath("$.data.email") { value(request.email) }
+        When("신규 멤버 가입 API 요청") {
+            val result = mockMvc.post("/members") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated() } // 201 Created 상태인지 확인
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.code") { value("create") }
+                jsonPath("$.data.email") { value(request.email) }
+            }.andReturn()
 
-        }.andReturn()
+            Then("신규 멤버 정보 DB에 저장") {
+                val responseBody = objectMapper.readTree(result.response.contentAsString)
+                val memberId = responseBody.get("data").get("id").asLong()
+                val savedMember = memberRepository.findById(memberId)
+                savedMember shouldNotBe null
+                savedMember?.email shouldBe request.email
+                savedMember?.phoneNumber shouldBe request.phoneNumber
+                savedMember?.status shouldBe MemberStatus.ACTIVE
+                passwordEncoder.matches(request.password, savedMember?.password) shouldBe true // 비밀번호가 암호화되었는지 확인
+            }
+        }
 
-        // Then: DB에서 직접 데이터를 조회하여 검증
-        val responseBody = objectMapper.readTree(result.response.contentAsString)
-        val memberId = responseBody.get("data").get("id").asLong()
-        val savedMember = memberRepository.findById(memberId)
+        When("이미 가입된 이후 재가입 시도") {
+            val result = mockMvc.post("/members") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isConflict() } // 409 Conflict 상태인지 확인
+                jsonPath("$.success") { value(false) }
+                jsonPath("$.code") { value(BusinessErrorCode.CONFLICT.name) }
+            }.andReturn()
 
-        savedMember shouldNotBe null
-        savedMember?.email shouldBe request.email
-        savedMember?.phoneNumber shouldBe request.phoneNumber
-        savedMember?.status shouldBe MemberStatus.ACTIVE
-        passwordEncoder.matches(request.password, savedMember?.password) shouldBe true // 비밀번호가 암호화되었는지 확인
-    }
-
-    @Test
-    fun `이미 존재하는 이메일로 가입을 시도하면 409 Conflict와 에러 응답을 반환한다`() {
-        // Given: 먼저 사용자를 하나 저장해 둠
-        val existingEmail = "test@example.com"
-        val existingMember = Member(
-            id = 1L,
-            email = existingEmail,
-            password = "password",
-            phoneNumber = "010-1234-5678",
-        )
-
-        memberRepository.insert(existingMember)
-
-        val request = MemberRegistrationRequest(
-            email = existingEmail,
-            password = "Password123!",
-            phoneNumber = "010-1111-2222"
-        )
-
-        // When & Then
-        mockMvc.post("/members") {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
-        }.andExpect {
-            status { isConflict() } // 409 Conflict 상태인지 확인
-            // ApiResponse 에러 형식 검증
-            jsonPath("$.success") { value(false) }
-            jsonPath("$.code") { value(BusinessErrorCode.CONFLICT.name) }
-            jsonPath("$.message") { value("이미 사용 중인 이메일입니다.") }
+            Then("이메일 중복으로 가입 실패 확인") {
+                val responseBody = objectMapper.readTree(result.response.contentAsString)
+                val message = responseBody.get("message").asText()
+                message shouldBe "이미 사용 중인 이메일입니다."
+            }
         }
     }
-    
-}
+
+})
+

--- a/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
+++ b/identity-service/src/test/kotlin/com/msa/identityservice/member/MemberControllerIntegrationTest.kt
@@ -5,7 +5,6 @@ import com.msa.identityservice.exception.BusinessErrorCode
 import com.msa.identityservice.jooq.enums.MemberStatus
 import com.msa.identityservice.member.controller.request.MemberRegistrationRequest
 import com.msa.identityservice.member.repository.MemberRepository
-import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -24,7 +23,6 @@ import java.util.*
 @AutoConfigureMockMvc // MockMvc를 실제 서버처럼 사용하기 위한 설정
 @ActiveProfiles("test")
 @Transactional
-@KotestTestScope
 class MemberControllerIntegrationTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,


### PR DESCRIPTION
## 📝 개요 (Description)

마이크로서비스 아키텍처의 단일 진입점(Single Point of Entry) 역할을 수행할 **Spring Cloud Gateway**를 도입합니다.

또한, Gateway에 **중앙 인증 필터**를 구현하여 모든 API 요청에 대한 인증을 중앙에서 처리하도록 구성했습니다.    
이와 함께, `identity-service`의 모든 통합 테스트 코드를 **Kotest의 `BehaviorSpec`**으로 리팩토링하여 가독성과 유지보수성을 향상시켰습니다.


## ✨ 주요 변경 사항 (Key Changes)

### 🚀 Gateway Service (신규 추가)

1.  **Spring Cloud Gateway 도입**:
    -   `spring-cloud-starter-gateway-server-webflux` 의존성을 기반으로 새로운 `gateway-service` 모듈을 생성했습니다.

2.  **라우팅 규칙 설정 (`application.yml`)**:
    -   `/identity-service/**` 경로로 들어오는 요청을 `identity-service`로 전달하는 라우팅 규칙을 설정했습니다.
    -   `RewritePath` 필터를 사용하여 외부 경로(`/identity-service`)를 제거하고 내부 서비스에 전달합니다.
    -   라우팅 우선순위(`order`)를 적용하여 공개 API와 보안 API 경로를 명확히 분리했습니다.

3.  **중앙 인증 필터 구현 (`AuthenticationGatewayFilterFactory`)**:
    -   모든 보안 API 요청에 대해 `Authorization` 헤더의 JWT를 검증합니다.
    -   토큰의 유효성(서명, 만료시간)뿐만 아니라, **Redis에 저장된 '활성 토큰 목록(Allow-list)'**과 비교하여 로그아웃 등으로 무효화된 토큰인지 이중으로 확인합니다.
    -   인증 성공 시, 요청 헤더에 `X-User-Id`, `X-User-Role` 등 검증된 사용자 정보를 추가하여 다운스트림 서비스로 전달합니다.

4.  **통합 테스트 작성 (`GatewayIntegrationTest`)**:
    -   Kotest의 `BehaviorSpec`과 `MockWebServer`를 사용하여 Gateway의 라우팅 및 인증 필터 로직을 검증하는 통합 테스트를 작성했습니다.

### 🛠️ Identity Service (리팩토링)

-  **테스트 코드 전체 리팩토링**:    
    -   기존의 모든 통합 테스트 코드를 JUnit 5 기반에서 Kotest의 **`BehaviorSpec`** 스타일로 마이그레이션했습니다.
    -   BDD(행위 주도 개발) 스타일을 적용하여, 테스트 코드의 가독성과 시나리오의 명확성을 향상시켰습니다.

