### PR TITLE
[ auth ] 인증 토큰 재발급 API 추가

### DIFF
--- a/modules/jwt/src/main/kotlin/msa/hotel/modules/jwt/token/JwtDecoder.kt
+++ b/modules/jwt/src/main/kotlin/msa/hotel/modules/jwt/token/JwtDecoder.kt
@@ -2,6 +2,7 @@ package msa.hotel.modules.jwt.token
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import msa.hotel.modules.jwt.config.properties.JwtProperties
@@ -26,6 +27,20 @@ class JwtDecoder(
             .build()
             .parseSignedClaims(token)
             .payload
+    }
+
+    fun extractAuthInfoCathExpired(token: String): Pair<TokenAuthInfo, Boolean> {
+        var isExpired = false
+        var claims: Claims? = null
+        try {
+            claims = getClaims(token)
+        } catch (expiredJwtException: ExpiredJwtException) {
+            // AccessToken 만료된 경우에도 토큰 재발급을 위해 예외에서 정보 추출claims
+            claims = expiredJwtException.claims
+            isExpired = true
+        }
+
+        return Pair(extractAuthInfo(claims), isExpired)
     }
 
     fun extractAuthInfo(token: String): TokenAuthInfo {

--- a/modules/jwt/src/main/kotlin/msa/hotel/modules/jwt/token/JwtDecoder.kt
+++ b/modules/jwt/src/main/kotlin/msa/hotel/modules/jwt/token/JwtDecoder.kt
@@ -31,14 +31,14 @@ class JwtDecoder(
 
     fun extractAuthInfoCathExpired(token: String): Pair<TokenAuthInfo, Boolean> {
         var isExpired = false
-        var claims: Claims? = null
-        try {
-            claims = getClaims(token)
-        } catch (expiredJwtException: ExpiredJwtException) {
-            // AccessToken 만료된 경우에도 토큰 재발급을 위해 예외에서 정보 추출claims
-            claims = expiredJwtException.claims
-            isExpired = true
-        }
+        val claims: Claims =
+            try {
+                getClaims(token)
+            } catch (expiredJwtException: ExpiredJwtException) {
+                // AccessToken 만료된 경우에도 토큰 재발급을 위해 예외에서 정보 추출claims
+                isExpired = true
+                expiredJwtException.claims
+            }
 
         return Pair(extractAuthInfo(claims), isExpired)
     }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/AuthService.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/AuthService.kt
@@ -4,6 +4,7 @@ import msa.hotel.modules.jwt.token.JwtDecoder
 import msa.hotel.modules.jwt.token.JwtProvider
 import msa.hotel.modules.jwt.token.dto.Token
 import msa.hotel.modules.jwt.token.dto.TokenUserInfo
+import msa.hotel.modules.web.exception.ErrorCode
 import msa.hotel.services.auth.application.auth.command.LoginCommand
 import msa.hotel.services.auth.application.auth.dto.AuthTokenDto
 import msa.hotel.services.auth.domain.auth.model.RefreshTokenInfo
@@ -99,6 +100,34 @@ class AuthService(
             refreshToken = refreshToken.value,
             refreshTokenIssuedAt = issuedAt,
             refreshTokenExpiration = refreshTokenExpiration,
+        )
+    }
+
+    fun reissueToken(
+        accessToken: String,
+        refreshToken: String,
+    ): AuthTokenDto {
+        // 1. AccessToken 유효성 검사
+        val (tokenAuthInfo, isExpired) = jwtDecoder.extractAuthInfoCathExpired(accessToken)
+
+        // 2. 만료된 AccessToken 토큰이 아닌 경우, 토큰 JTI가 유효해야함
+        if (!isExpired && !tokenRepo.existActiveJti(tokenAuthInfo.jti)) {
+            throw ErrorCode.UNAUTHORIZED.exception("로그아웃 처리 된 인증 정보입니다. 다시 로그인 해주세요.")
+        }
+
+        // 3. RefreshToken 유효성 검사
+        val refreshTokenInfo =
+            tokenRepo.findRefreshTokenInfo(tokenAuthInfo.tokenUserInfo) ?: throw ErrorCode.UNAUTHORIZED.exception("인증 세션 정보가 존재하지 않습니다.")
+
+        if (refreshTokenInfo.token != refreshToken) {
+            throw ErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")
+        }
+
+        // 4. 인증 토큰 재발급
+        return generateAuthToken(
+            tokenAuthInfo.tokenUserInfo,
+            refreshTokenInfo.loginAt,
+            pastActiveJti = tokenAuthInfo.jti,
         )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/port/AuthTokenRepository.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/port/AuthTokenRepository.kt
@@ -16,4 +16,6 @@ interface AuthTokenRepository {
         maxLoginClient: UInt,
         pastActiveJti: String? = null,
     )
+
+    fun existActiveJti(jti: String): Boolean
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/persistence/redis/AuthTokenRepositoryImpl.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/persistence/redis/AuthTokenRepositoryImpl.kt
@@ -46,9 +46,11 @@ class AuthTokenRepositoryImpl(
         val refreshTokenTtl = Duration.between(issuedAt, refreshTokenExpiration).seconds
         val sessionInfoJson = ObjectMapper().registerModule(JavaTimeModule()).writeValueAsString(refreshTokenInfo)
 
+        val pastActiveJtiKey: String? = if (pastActiveJti != null) makeActiveJtiKey(pastActiveJti) else null
+
         rt.execute(
             loginScript,
-            listOf(sessionAgesKey, refreshTokensKey, activeJtiKey, pastActiveJti),
+            listOf(sessionAgesKey, refreshTokensKey, activeJtiKey, pastActiveJtiKey),
             maxLoginClient.toString(),
             userInfo.deviceId,
             refreshTokenExpiresAt,
@@ -57,5 +59,13 @@ class AuthTokenRepositoryImpl(
             accessTokenTtl.toString(),
             refreshTokenTtl.toString(),
         )
+    }
+
+    override fun existActiveJti(jti: String): Boolean {
+        val activeJtiKey = makeActiveJtiKey(jti)
+
+        rt.opsForValue().get(activeJtiKey) ?: return false
+
+        return true
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/AuthController.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/AuthController.kt
@@ -28,4 +28,14 @@ class AuthController(
 
         return setAuthTokenHeaders(authToken)
     }
+
+    @PostMapping("/reissue")
+    fun reissueToken(): ResponseEntity<Unit> {
+        val accessToken = tokenExtractor.getAccessToken()
+        val refreshToken = tokenExtractor.getRefreshToken()
+
+        val authToken: AuthTokenDto = authService.reissueToken(accessToken, refreshToken)
+
+        return setAuthTokenHeaders(authToken)
+    }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/header/SetAuthTokenHeaders.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/header/SetAuthTokenHeaders.kt
@@ -5,6 +5,7 @@ import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_PREFIX
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_REFRESH_COOKIE_NAME
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import java.time.Duration
@@ -21,11 +22,11 @@ fun setAuthTokenHeaders(authToken: AuthTokenDto): ResponseEntity<Unit> {
             .build()
 
     return ResponseEntity
-        .ok()
-        .header(T_ACCESS_HEADER_NAME, getAccessTokenHeaderValue(authToken.accessToken))
+        .status(HttpStatus.CREATED)
+        .header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(authToken.accessToken))
         .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
         .header("Access-Control-Expose-Headers", T_ACCESS_HEADER_NAME)
         .build()
 }
 
-private fun getAccessTokenHeaderValue(accessToken: String): String = "$T_ACCESS_HEADER_PREFIX$accessToken"
+fun makeAccessTokenHeaderValue(accessToken: String): String = "$T_ACCESS_HEADER_PREFIX$accessToken"

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
@@ -18,6 +18,7 @@ import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_PREFIX
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_REFRESH_COOKIE_NAME
+import msa.hotel.services.auth.infrastructure.web.auth.header.makeAccessTokenHeaderValue
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.redis.core.RedisTemplate
@@ -41,7 +42,6 @@ class AuthIntegrationTest(
     private val jwtDecoder: JwtDecoder,
     private val redisTemplate: RedisTemplate<String, String>,
 ) : BehaviorSpec({
-
         fun performLoginAndGetTokens(request: LoginRequest): Pair<String, Cookie> {
             val result =
                 mockMvc
@@ -84,7 +84,7 @@ class AuthIntegrationTest(
                             contentType = MediaType.APPLICATION_JSON
                             content = om.writeValueAsString(request)
                         }.andExpect {
-                            status { isOk() }
+                            status { isCreated() }
                         }.andReturn()
 
                 Then("인증 토큰 발급 및 리프레시 토큰 정보 Redis 저장") {
@@ -137,6 +137,50 @@ class AuthIntegrationTest(
                     // 3. 가장 마지막 로그인한 세션(newDeviceId) 토큰은 존재해야 함
                     val lastRefreshToken = redisTemplate.opsForHash<String, String>().get(refreshTokensKey, newDeviceId)
                     lastRefreshToken shouldNotBe null
+                }
+            }
+
+            When("로그인 이후 인증 토큰 재발급 API 요청") {
+                val request = createLoginRequest(registerCommand, loginDeviceId)
+                val (pastAccessToken, pastRefreshTokenCookie) = performLoginAndGetTokens(request)
+                val pastRefreshToken = pastRefreshTokenCookie.value
+
+                val result =
+                    mockMvc
+                        .post("/auth/reissue") {
+                            cookie(pastRefreshTokenCookie)
+                            header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(pastAccessToken)) // 재발급 시에도 AccessToken 확인
+                        }.andExpect {
+                            status { isCreated() }
+                        }.andReturn()
+
+                Then("인증 토큰 재발급 및 기존 인증 토큰 무효화") {
+                    // AccessToken Header 재발급 확인
+                    val accessTokenHeader = result.response.getHeader(T_ACCESS_HEADER_NAME)
+                    accessTokenHeader shouldNotBe null
+                    val reissueAccessToken = accessTokenHeader!!.substring(T_ACCESS_HEADER_PREFIX.length)
+                    reissueAccessToken shouldNotBe pastAccessToken
+
+                    // RefreshToken Cookie 재발급 확인
+                    val refreshTokenCookie = result.response.getCookie(T_REFRESH_COOKIE_NAME)
+                    refreshTokenCookie shouldNotBe null
+                    val reissueRefreshToken = refreshTokenCookie?.value
+                    reissueRefreshToken shouldNotBe pastRefreshToken
+
+                    // 재발급된 리프레시 토큰 저장 확인 & 기존 인증 토큰 무효화 확인
+                    val tokenAuthInfo = jwtDecoder.extractAuthInfo(pastAccessToken)
+                    val savedRefreshTokenInfo = repo.findRefreshTokenInfo(tokenAuthInfo.tokenUserInfo)
+                    savedRefreshTokenInfo shouldNotBe null
+                    val storedRefreshToken = savedRefreshTokenInfo!!.token
+                    storedRefreshToken shouldNotBe pastRefreshToken
+
+                    // 재발급된 토큰 유효성 검증
+                    storedRefreshToken shouldBe reissueRefreshToken
+                    val reissueTokenAuthInfo = jwtDecoder.extractAuthInfo(reissueAccessToken)
+                    val reissueUserInfo = reissueTokenAuthInfo.tokenUserInfo
+                    reissueUserInfo.userId shouldBe registeredIdentity.id.value
+                    reissueUserInfo.role shouldBe registeredIdentity.role.name
+                    reissueUserInfo.deviceId shouldBe loginDeviceId
                 }
             }
         }


### PR DESCRIPTION
## 📝 개요 (Description)

###  JWT 인증 토큰 재발급 API 구현

로그인 기능에 이어, 만료된 AccessToken을 RefreshToken을 사용하여 갱신할 수 있는 **인증 토큰 재발급 API (`POST /auth/reissue`)를 구현**했습니다. 이를 통해 사용자는 세션을 안전하게 연장하고 지속적인 서비스 이용이 가능해집니다.

## ✨ 주요 변경 사항 (Key Changes)

-   **토큰 재발급 API 엔드포인트 추가 (`POST /auth/reissue`)**
    -   Request의 `Authorization` 헤더와 `refreshToken` 쿠키를 통해 기존 AccessToken과 RefreshToken을 전달받습니다.
    -   인증 성공 시, 새로운 토큰 쌍을 발급하여 헤더와 쿠키에 설정해 응답합니다.

-   **토큰 유효성 검증 로직 강화**
    -   `JwtDecoder`를 개선하여, **만료된 AccessToken에서도 사용자 정보를 안전하게 추출**할 수 있도록 `extractAuthInfoCathExpired` 메서드를 추가했습니다.
    -   전달받은 RefreshToken이 Redis에 저장된 세션 정보와 일치하는지 검증하여 탈취된 토큰의 사용 가능성을 차단합니다.

-   **보안 강화를 위한 기존 토큰 무효화**
    -   토큰 재발급이 성공하면, 이전에 사용되었던 AccessToken의 JTI(JWT ID)를 Redis에서 제거합니다.
    -   이를 통해 한 번 재발급에 사용된 토큰이 다시 사용되는 것을 방지하여 보안을 강화했습니다.

-   **통합 테스트 추가**
    -   정상적인 토큰 재발급 시나리오를 검증하고, 재발급 후 기존 토큰이 무효화되는지를 확인하는 통합 테스트(`AuthIntegrationTest`)를 추가했습니다.
