### PR TITLE
[ auth ] 접속 중인 세션 로그아웃 API & 다른 접속 중인 세션 로그아웃 API 추가

### DIFF
--- a/modules/jwt/src/main/kotlin/msa/hotel/modules/jwt/token/JwtDecoder.kt
+++ b/modules/jwt/src/main/kotlin/msa/hotel/modules/jwt/token/JwtDecoder.kt
@@ -48,6 +48,9 @@ class JwtDecoder(
             val claims = getClaims(token)
 
             return extractAuthInfo(claims)
+        } catch (e: ExpiredJwtException) {
+            logger.error { "Extract AuthInfo exception (token): $e" }
+            throw ErrorCode.UNAUTHORIZED.exception("인증이 만료됐습니다.")
         } catch (e: Exception) {
             logger.error { "Extract AuthInfo exception (token): $e" }
             throw ErrorCode.UNAUTHORIZED.exception("인증 정보가 올바르지 않습니다.")

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/AuthService.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/AuthService.kt
@@ -7,6 +7,7 @@ import msa.hotel.modules.jwt.token.dto.TokenUserInfo
 import msa.hotel.modules.web.exception.ErrorCode
 import msa.hotel.services.auth.application.auth.command.LoginCommand
 import msa.hotel.services.auth.application.auth.dto.AuthTokenDto
+import msa.hotel.services.auth.application.auth.dto.SessionInfoDto
 import msa.hotel.services.auth.domain.auth.model.RefreshTokenInfo
 import msa.hotel.services.auth.domain.auth.policy.MaximumLoginClientPolicy
 import msa.hotel.services.auth.domain.auth.policy.TokenExpirationPolicy.ACCESS_TOKEN_EXPIRATION_IN_HOURS
@@ -15,6 +16,7 @@ import msa.hotel.services.auth.domain.auth.port.AuthTokenRepository
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneOffset.UTC
 import java.util.Date
 
 @Service
@@ -128,6 +130,52 @@ class AuthService(
             tokenAuthInfo.tokenUserInfo,
             refreshTokenInfo.loginAt,
             pastActiveJti = tokenAuthInfo.jti,
+        )
+    }
+
+    fun logout(
+        accessToken: String,
+        deviceId: String? = null,
+    ): SessionInfoDto {
+        // 현재 접속 기기가 아닌 다른 접속 기기의 로그아웃을 요청한 경우, 만료안된 토큰만 허용
+        // 1. AccessToken 유효성 검사
+        val tokenAuthInfo =
+            if (deviceId != null) {
+                jwtDecoder.extractAuthInfo(accessToken)
+            } else {
+                jwtDecoder.extractAuthInfoCathExpired(accessToken).first
+            }
+        val tokenDeviceId = tokenAuthInfo.tokenUserInfo.deviceId
+
+        if (tokenDeviceId == deviceId) {
+            throw ErrorCode.BAD_REQUEST.exception("다른 기기 로그아웃 요청 시, 현재 기기 정보 요청은 유효하지 않습니다.")
+        }
+
+        // 현재 접속 기기가 아닌 다른 접속 기기의 로그아웃을 요청한 경우, 지금 세션이 활성화된 정보인지 한번 더 검증
+        var logoutDeviceId = tokenDeviceId
+        if (deviceId != null) {
+            logoutDeviceId = deviceId
+            if (!tokenRepo.existActiveJti(tokenAuthInfo.jti)) {
+                throw ErrorCode.UNAUTHORIZED.exception("현재 세션이 로그아웃되어 다른 세션을 로그아웃할 수 없습니다")
+            }
+        }
+
+        // 2. 로그아웃 요청한 Device ID가 로그인 중인 기기 정보가 맞는지 검사
+        val logoutRefreshTokenInfo =
+            tokenRepo.findRefreshTokenInfo(tokenAuthInfo.tokenUserInfo, logoutDeviceId)
+                ?: throw ErrorCode.UNAUTHORIZED.exception("로그아웃 요청한 $logoutDeviceId 기기 인증 정보가 존재하지 않습니다. 이미 로그아웃 된 상태입니다.")
+
+        // 3. 로그아웃 Lua 스크립트 실행 (로그아웃 요청 된 AccessToken, RefreshToken 무력화)
+        tokenRepo.deleteAuthTokenByLogout(
+            tokenAuthInfo.tokenUserInfo,
+            logoutActiveJti = logoutRefreshTokenInfo.accessTokenJti,
+            logoutDeviceId = logoutDeviceId,
+        )
+
+        return SessionInfoDto(
+            deviceId = logoutDeviceId,
+            loginDateTime = logoutRefreshTokenInfo.loginAt.atZone(UTC).toLocalDateTime(),
+            lastActivityDateTime = logoutRefreshTokenInfo.lastActivityAt.atZone(UTC).toLocalDateTime(),
         )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/dto/SessionInfoDto.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/dto/SessionInfoDto.kt
@@ -1,0 +1,9 @@
+package msa.hotel.services.auth.application.auth.dto
+
+import java.time.LocalDateTime
+
+data class SessionInfoDto(
+    val deviceId: String,
+    val loginDateTime: LocalDateTime,
+    val lastActivityDateTime: LocalDateTime,
+)

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/config/RedisConfig.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/config/RedisConfig.kt
@@ -48,4 +48,13 @@ class RedisConfig(
 
         return script
     }
+
+    @Bean
+    fun logoutScript(): DefaultRedisScript<Long> {
+        val script = DefaultRedisScript<Long>()
+        script.setLocation(ClassPathResource("scripts/logout.lua"))
+        script.resultType = Long::class.java
+
+        return script
+    }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/model/RefreshTokenInfo.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/model/RefreshTokenInfo.kt
@@ -1,5 +1,6 @@
 package msa.hotel.services.auth.domain.auth.model
 
+import msa.hotel.modules.web.exception.ErrorCode
 import java.time.Instant
 
 data class RefreshTokenInfo(
@@ -8,4 +9,19 @@ data class RefreshTokenInfo(
     val loginAt: Instant,
     val lastActivityAt: Instant,
     val expiresAt: Instant,
-)
+) {
+    init {
+        if (accessTokenJti.isBlank()) {
+            throw ErrorCode.CONFLICT.exception("access token jti is blank")
+        }
+        if (token.isBlank()) {
+            throw ErrorCode.CONFLICT.exception("refresh token is blank")
+        }
+        if (lastActivityAt.isBefore(loginAt)) {
+            throw ErrorCode.CONFLICT.exception("last activity at is before login at")
+        }
+        if (expiresAt.isBefore(loginAt)) {
+            throw ErrorCode.CONFLICT.exception("refresh token expires at is before login at")
+        }
+    }
+}

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/port/AuthTokenRepository.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/port/AuthTokenRepository.kt
@@ -18,4 +18,15 @@ interface AuthTokenRepository {
     )
 
     fun existActiveJti(jti: String): Boolean
+
+    fun findRefreshTokenInfo(
+        userInfo: TokenUserInfo,
+        logoutDeviceId: String,
+    ): RefreshTokenInfo?
+
+    fun deleteAuthTokenByLogout(
+        userInfo: TokenUserInfo,
+        logoutActiveJti: String,
+        logoutDeviceId: String,
+    )
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/identity/model/Identity.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/identity/model/Identity.kt
@@ -1,5 +1,6 @@
 package msa.hotel.services.auth.domain.identity.model
 
+import msa.hotel.modules.web.exception.ErrorCode
 import java.time.Instant
 
 class Identity(
@@ -15,6 +16,27 @@ class Identity(
     deletedAt: Instant? = null,
     val createdAt: Instant,
 ) {
+    init {
+        if (email.isBlank()) {
+            throw ErrorCode.CONFLICT.exception("email is blank")
+        }
+        if (!email.matches(".+@.+\\..+".toRegex())) {
+            throw ErrorCode.CONFLICT.exception("invalid email format")
+        }
+        if (passwordHash.isBlank()) {
+            throw ErrorCode.CONFLICT.exception("password hash is blank")
+        }
+        if (lockedUntil != null && lockedUntil.isBefore(createdAt)) {
+            throw ErrorCode.CONFLICT.exception("locked until is before created at")
+        }
+        if (lastLoginAt != null && lastLoginAt.isAfter(createdAt)) {
+            throw ErrorCode.CONFLICT.exception("last login at is after created at")
+        }
+        if (deletedAt != null && deletedAt.isBefore(createdAt)) {
+            throw ErrorCode.CONFLICT.exception("deleted at is before created at")
+        }
+    }
+
     var passwordHash = passwordHash
         private set
 

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/persistence/redis/AuthTokenRepositoryImpl.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/persistence/redis/AuthTokenRepositoryImpl.kt
@@ -19,10 +19,21 @@ class AuthTokenRepositoryImpl(
     private val rt: RedisTemplate<String, String>,
     private val om: ObjectMapper,
     private val loginScript: RedisScript<Long>,
+    private val logoutScript: RedisScript<Long>,
 ) : AuthTokenRepository {
     override fun findRefreshTokenInfo(userInfo: TokenUserInfo): RefreshTokenInfo? {
         val key = makeRefreshTokenKey(userInfo.role, userInfo.userId)
         val refreshTokenInfoString = rt.opsForHash<String, String>().get(key, userInfo.deviceId) ?: return null
+
+        return om.readValue(refreshTokenInfoString, RefreshTokenInfo::class.java)
+    }
+
+    override fun findRefreshTokenInfo(
+        userInfo: TokenUserInfo,
+        logoutDeviceId: String,
+    ): RefreshTokenInfo? {
+        val key = makeRefreshTokenKey(userInfo.role, userInfo.userId)
+        val refreshTokenInfoString = rt.opsForHash<String, String>().get(key, logoutDeviceId) ?: return null
 
         return om.readValue(refreshTokenInfoString, RefreshTokenInfo::class.java)
     }
@@ -67,5 +78,22 @@ class AuthTokenRepositoryImpl(
         rt.opsForValue().get(activeJtiKey) ?: return false
 
         return true
+    }
+
+    override fun deleteAuthTokenByLogout(
+        userInfo: TokenUserInfo,
+        logoutActiveJti: String,
+        logoutDeviceId: String,
+    ) {
+        val refreshTokenKey = makeRefreshTokenKey(role = userInfo.role, userId = userInfo.userId)
+        val sessionAgesKey = makeSessionKey(role = userInfo.role, userId = userInfo.userId)
+        val activeJtiKey = makeActiveJtiKey(logoutActiveJti)
+
+        // --- 원자적 스크립트 실행 ---
+        rt.execute(
+            logoutScript,
+            listOf(refreshTokenKey, sessionAgesKey, activeJtiKey),
+            logoutDeviceId,
+        )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/AuthController.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/AuthController.kt
@@ -1,12 +1,17 @@
 package msa.hotel.services.auth.infrastructure.web.auth
 
 import jakarta.validation.Valid
+import msa.hotel.modules.web.response.Response
 import msa.hotel.services.auth.application.auth.AuthService
 import msa.hotel.services.auth.application.auth.dto.AuthTokenDto
 import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
+import msa.hotel.services.auth.infrastructure.web.auth.dto.LogoutRequest
+import msa.hotel.services.auth.infrastructure.web.auth.dto.SessionInfoResponse
 import msa.hotel.services.auth.infrastructure.web.auth.header.RequestHeaderTokenExtractor
+import msa.hotel.services.auth.infrastructure.web.auth.header.deleteAuthTokenHeaders
 import msa.hotel.services.auth.infrastructure.web.auth.header.setAuthTokenHeaders
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -37,5 +42,44 @@ class AuthController(
         val authToken: AuthTokenDto = authService.reissueToken(accessToken, refreshToken)
 
         return setAuthTokenHeaders(authToken)
+    }
+
+    @DeleteMapping("/logout")
+    fun logout(): ResponseEntity<Response<SessionInfoResponse>> {
+        val accessToken = tokenExtractor.getAccessToken()
+        val sessionInfo = authService.logout(accessToken)
+
+        val data =
+            SessionInfoResponse(
+                deviceId = sessionInfo.deviceId,
+                loginDateTime = sessionInfo.loginDateTime,
+                lastActivityDateTime = sessionInfo.lastActivityDateTime,
+            )
+
+        return deleteAuthTokenHeaders(
+            message = "로그아웃 되었습니다.(${sessionInfo.deviceId})",
+            data = data,
+        )
+    }
+
+    @DeleteMapping("/logout-device")
+    fun logout(
+        @Valid @RequestBody
+        request: LogoutRequest,
+    ): ResponseEntity<Response<SessionInfoResponse>> {
+        val accessToken = tokenExtractor.getAccessToken()
+        val sessionInfo = authService.logout(accessToken, request.deviceId)
+
+        val data =
+            SessionInfoResponse(
+                deviceId = sessionInfo.deviceId,
+                loginDateTime = sessionInfo.loginDateTime,
+                lastActivityDateTime = sessionInfo.lastActivityDateTime,
+            )
+
+        return deleteAuthTokenHeaders(
+            message = "로그아웃 되었습니다.(${sessionInfo.deviceId})",
+            data = data,
+        )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/LogoutAllResponse.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/LogoutAllResponse.kt
@@ -1,0 +1,5 @@
+package msa.hotel.services.auth.infrastructure.web.auth.dto
+
+data class LogoutAllResponse(
+    val logoutInfos: List<SessionInfoResponse>,
+)

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/LogoutRequest.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/LogoutRequest.kt
@@ -1,0 +1,8 @@
+package msa.hotel.services.auth.infrastructure.web.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class LogoutRequest(
+    @field:NotBlank(message = "로그아웃 기기 ID는 필수입니다.")
+    val deviceId: String?,
+)

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/SessionInfoResponse.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/SessionInfoResponse.kt
@@ -1,0 +1,9 @@
+package msa.hotel.services.auth.infrastructure.web.auth.dto
+
+import java.time.LocalDateTime
+
+data class SessionInfoResponse(
+    val deviceId: String,
+    val loginDateTime: LocalDateTime,
+    val lastActivityDateTime: LocalDateTime,
+)

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/header/SetAuthTokenHeaders.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/header/SetAuthTokenHeaders.kt
@@ -1,5 +1,6 @@
 package msa.hotel.services.auth.infrastructure.web.auth.header
 
+import msa.hotel.modules.web.response.Response
 import msa.hotel.services.auth.application.auth.dto.AuthTokenDto
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_PREFIX
@@ -30,3 +31,28 @@ fun setAuthTokenHeaders(authToken: AuthTokenDto): ResponseEntity<Unit> {
 }
 
 fun makeAccessTokenHeaderValue(accessToken: String): String = "$T_ACCESS_HEADER_PREFIX$accessToken"
+
+fun <T> deleteAuthTokenHeaders(
+    message: String,
+    data: T,
+): ResponseEntity<Response<T>> {
+    val deleteCookie =
+        ResponseCookie
+            .from(T_REFRESH_COOKIE_NAME, "")
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(0)
+            .build()
+
+    val responseBody =
+        Response.delete(
+            message = message,
+            data = data,
+        )
+
+    return ResponseEntity
+        .ok()
+        .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+        .body(responseBody)
+}

--- a/services/auth/src/main/resources/scripts/logout.lua
+++ b/services/auth/src/main/resources/scripts/logout.lua
@@ -1,0 +1,16 @@
+-- KEYS[1]: refresh_tokens HASH key
+-- KEYS[2]: session_ages ZSET key
+-- KEYS[3]: active_jti key
+
+-- ARGV[1]: deviceId
+
+-- 1. Hash에서 특정 기기(deviceId)의 리프레시 토큰 세션 삭제
+redis.call('HDEL', KEYS[1], ARGV[1])
+
+-- 2. ZSET에서 해당 deviceId 멤버 삭제
+redis.call('ZREM', KEYS[2], ARGV[1])
+
+-- 3. 현재 Access Token 관련 Active 정보를 삭제
+redis.call('DEL', KEYS[3])
+
+return 1

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
@@ -15,6 +15,7 @@ import msa.hotel.services.auth.domain.auth.port.AuthTokenRepository
 import msa.hotel.services.auth.domain.identity.model.Role
 import msa.hotel.services.auth.infrastructure.persistence.redis.key.AuthTokenKey.makeRefreshTokenKey
 import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
+import msa.hotel.services.auth.infrastructure.web.auth.dto.LogoutRequest
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_PREFIX
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_REFRESH_COOKIE_NAME
@@ -25,6 +26,7 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.post
 import org.springframework.transaction.annotation.Transactional
 import java.lang.Thread.sleep
@@ -181,6 +183,76 @@ class AuthIntegrationTest(
                     reissueUserInfo.userId shouldBe registeredIdentity.id.value
                     reissueUserInfo.role shouldBe registeredIdentity.role.name
                     reissueUserInfo.deviceId shouldBe loginDeviceId
+                }
+            }
+
+            When("로그인 이후 로그아웃 API 요청") {
+                val request = createLoginRequest(registerCommand, loginDeviceId)
+                val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(request)
+
+                val result =
+                    mockMvc
+                        .delete("/auth/logout") {
+                            cookie(refreshTokenCookie)
+                            header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessToken))
+                        }.andExpect {
+                            status { isOk() }
+                        }.andReturn()
+
+                Then("이전에 발급된 AccessToken & RefreshToken 모두 무효화") {
+                    // 응답 내역에 리프레시 토큰 쿠키 삭제
+                    val refreshTokenCookie = result.response.getCookie(T_REFRESH_COOKIE_NAME)
+                    refreshTokenCookie!!.value.isNullOrBlank() shouldBe true
+
+                    // 해당 접속 세션 삭제 -> 리프레시 토큰
+                    val tokenAuthInfo = jwtDecoder.extractAuthInfo(accessToken)
+                    val savedRefreshTokenInfo = repo.findRefreshTokenInfo(tokenAuthInfo.tokenUserInfo)
+                    savedRefreshTokenInfo shouldBe null
+
+                    // 활성 AccessToken 내역 삭제
+                    val checkActiveJti = repo.existActiveJti(tokenAuthInfo.jti)
+                    checkActiveJti shouldBe false
+                }
+            }
+
+            When("로그인한 인증 정보로 다른 Device로 접속 세션 로그아웃 API 요청") {
+                val loginRequest = createLoginRequest(registerCommand, loginDeviceId)
+                val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest)
+
+                val anotherDeviceId = "another-device"
+                val anotherLoginRequest = createLoginRequest(registerCommand, anotherDeviceId)
+                val (anotherAccessToken, anotherRefreshTokenCookie) = performLoginAndGetTokens(anotherLoginRequest)
+
+                val logoutRequest = LogoutRequest(anotherDeviceId)
+
+                val result =
+                    mockMvc
+                        .delete("/auth/logout-device") {
+                            cookie(refreshTokenCookie)
+                            header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessToken))
+                            content = om.writeValueAsString(logoutRequest)
+                            contentType = MediaType.APPLICATION_JSON
+                        }.andExpect {
+                            status { isOk() }
+                        }.andReturn()
+
+                Then("다른 디바이스로 접속한 세션 삭제 -> AccessToken, RefreshToken 즉시 무효화") {
+                    val anotherAccessTokenInfo = jwtDecoder.extractAuthInfo(anotherAccessToken)
+                    // 리프레시 토큰 내역 삭제 확인
+                    val savedAnotherRefreshTokenInfo = repo.findRefreshTokenInfo(anotherAccessTokenInfo.tokenUserInfo)
+                    savedAnotherRefreshTokenInfo shouldBe null
+
+                    // 활성 JTI 삭제 확인
+                    val checkAnotherActiveJti = repo.existActiveJti(anotherAccessTokenInfo.jti)
+                    checkAnotherActiveJti shouldBe false
+
+                    // 다른 접속 중인 세션은 여전히 유효함을 확인
+                    val accessTokenInfo = jwtDecoder.extractAuthInfo(accessToken)
+                    val savedRefreshTokenInfo = repo.findRefreshTokenInfo(accessTokenInfo.tokenUserInfo)
+                    savedRefreshTokenInfo shouldNotBe null
+
+                    val checkActiveJti = repo.existActiveJti(accessTokenInfo.jti)
+                    checkActiveJti shouldBe true
                 }
             }
         }

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
@@ -221,20 +221,19 @@ class AuthIntegrationTest(
 
                 val anotherDeviceId = "another-device"
                 val anotherLoginRequest = createLoginRequest(registerCommand, anotherDeviceId)
-                val (anotherAccessToken, anotherRefreshTokenCookie) = performLoginAndGetTokens(anotherLoginRequest)
+                val anotherAccessToken = performLoginAndGetTokens(anotherLoginRequest).first
 
                 val logoutRequest = LogoutRequest(anotherDeviceId)
 
-                val result =
-                    mockMvc
-                        .delete("/auth/logout-device") {
-                            cookie(refreshTokenCookie)
-                            header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessToken))
-                            content = om.writeValueAsString(logoutRequest)
-                            contentType = MediaType.APPLICATION_JSON
-                        }.andExpect {
-                            status { isOk() }
-                        }.andReturn()
+                mockMvc
+                    .delete("/auth/logout-device") {
+                        cookie(refreshTokenCookie)
+                        header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessToken))
+                        content = om.writeValueAsString(logoutRequest)
+                        contentType = MediaType.APPLICATION_JSON
+                    }.andExpect {
+                        status { isOk() }
+                    }.andReturn()
 
                 Then("다른 디바이스로 접속한 세션 삭제 -> AccessToken, RefreshToken 즉시 무효화") {
                     val anotherAccessTokenInfo = jwtDecoder.extractAuthInfo(anotherAccessToken)


### PR DESCRIPTION
## 📝 개요 (Description)

### 현재 및 특정 기기 로그아웃 API 구현

토큰 재발급 기능에 이어, 사용자의 인증 세션을 안전하게 종료할 수 있는 **로그아웃 API를 구현**했습니다. 현재 사용 중인 기기뿐만 아니라, 다른 기기에서 활성화된 세션을 원격으로 종료하는 기능도 함께 추가되었습니다.

## ✨ 주요 변경 사항 (Key Changes)

-   **로그아웃 API 엔드포인트 추가**
    -   **`DELETE /auth/logout`**: 현재 요청을 보낸 기기의 세션을 종료합니다.
    -   **`DELETE /auth/logout-device`**: Request Body로 전달받은 `deviceId`에 해당하는 원격 기기의 세션을 강제 종료합니다.

-   **안전한 세션 무효화 처리**
    -   로그아웃 요청 시, Redis에 저장된 **RefreshToken과 세션 정보를 즉시 삭제**합니다.
    -   활성 상태의 **AccessToken JTI(JWT ID)를 제거**하여, 기존 AccessToken 토큰이 사용될 수 없도록 즉시 무효화합니다.
    -   이 모든 과정은 **Redis Lua 스크립트(`logout.lua`)**를 통해 **원자적(Atomic)으로 실행**되어 데이터 정합성을 보장합니다.

-   **사용자 경험 개선**
    -   로그아웃 성공 시, 클라이언트의 `refreshToken` 쿠키를 삭제하도록 `Set-Cookie` 헤더(`Max-Age=0`)를 응답에 포함시켜 깔끔하게 세션이 정리되도록 구현했습니다.
    -   어떤 기기가 로그아웃되었는지 명확히 알려주기 위해 응답 본문에 해당 기기의 세션 정보를 포함했습니다.

-   **통합 테스트 작성**
    -   현재 기기 로그아웃 시나리오와 다른 기기를 원격으로 로그아웃시키는 시나리오를 각각 검증하는 통합 테스트(`AuthIntegrationTest`)를 추가하여 기능의 안정성을 확보했습니다.