### PR TITLE
[ auth ] 모든 기기에서 로그아웃 API & 접속 중인 세션 정보 응답 API 추가

### DIFF
--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/AuthService.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/auth/AuthService.kt
@@ -156,7 +156,7 @@ class AuthService(
         if (deviceId != null) {
             logoutDeviceId = deviceId
             if (!tokenRepo.existActiveJti(tokenAuthInfo.jti)) {
-                throw ErrorCode.UNAUTHORIZED.exception("현재 세션이 로그아웃되어 다른 세션을 로그아웃할 수 없습니다")
+                throw ErrorCode.UNAUTHORIZED.exception("현재 세션이 유효하지 않아 다른 세션을 로그아웃할 수 없습니다")
             }
         }
 
@@ -177,5 +177,46 @@ class AuthService(
             loginDateTime = logoutRefreshTokenInfo.loginAt.atZone(UTC).toLocalDateTime(),
             lastActivityDateTime = logoutRefreshTokenInfo.lastActivityAt.atZone(UTC).toLocalDateTime(),
         )
+    }
+
+    fun logoutAll(accessToken: String): List<SessionInfoDto> {
+        // 1. AccessToken 유효성 검사
+        val tokenAuthInfo = jwtDecoder.extractAuthInfo(accessToken)
+        if (!tokenRepo.existActiveJti(tokenAuthInfo.jti)) {
+            throw ErrorCode.UNAUTHORIZED.exception("현재 세션이 유효하지 않아 모든 세션을 로그아웃할 수 없습니다")
+        }
+
+        // 2. 모든 접속 세션 내역 확인
+        val sessionInfos = getSessions(tokenAuthInfo.tokenUserInfo)
+        if (sessionInfos.isEmpty()) {
+            throw ErrorCode.CONFLICT.exception("이미 모두 로그아웃 처리 되었습니다.")
+        }
+
+        // 3. 모든 기기 로그아웃 Lua 스크립트 실행 (로그아웃 요청 된 AccessToken, RefreshToken 무력화)
+        tokenRepo.deleteAuthTokenByLogoutAll(tokenAuthInfo.tokenUserInfo)
+
+        return sessionInfos
+    }
+
+    fun getSessions(accessToken: String): List<SessionInfoDto> {
+        val tokenAuthInfo = jwtDecoder.extractAuthInfo(accessToken)
+        if (!tokenRepo.existActiveJti(tokenAuthInfo.jti)) {
+            throw ErrorCode.UNAUTHORIZED.exception("현재 세션이 유효하지 않아 모든 세션을 로그아웃할 수 없습니다")
+        }
+
+        return getSessions(tokenAuthInfo.tokenUserInfo)
+    }
+
+    fun getSessions(userInfo: TokenUserInfo): List<SessionInfoDto> {
+        val refreshTokenInfos = tokenRepo.findAllRefreshTokenInfo(userInfo)
+
+        return refreshTokenInfos.map {
+            val authInfo = jwtDecoder.extractAuthInfo(it.token)
+            SessionInfoDto(
+                deviceId = authInfo.tokenUserInfo.deviceId,
+                loginDateTime = it.loginAt.atZone(UTC).toLocalDateTime(),
+                lastActivityDateTime = it.lastActivityAt.atZone(UTC).toLocalDateTime(),
+            )
+        }
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/config/RedisConfig.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/config/RedisConfig.kt
@@ -57,4 +57,13 @@ class RedisConfig(
 
         return script
     }
+
+    @Bean
+    fun logoutAllScript(): DefaultRedisScript<Long> {
+        val script = DefaultRedisScript<Long>()
+        script.setLocation(ClassPathResource("scripts/logout-all.lua"))
+        script.resultType = Long::class.java
+
+        return script
+    }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/port/AuthTokenRepository.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/auth/port/AuthTokenRepository.kt
@@ -29,4 +29,8 @@ interface AuthTokenRepository {
         logoutActiveJti: String,
         logoutDeviceId: String,
     )
+
+    fun findAllRefreshTokenInfo(userInfo: TokenUserInfo): List<RefreshTokenInfo>
+
+    fun deleteAuthTokenByLogoutAll(userInfo: TokenUserInfo)
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/persistence/redis/AuthTokenRepositoryImpl.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/persistence/redis/AuthTokenRepositoryImpl.kt
@@ -13,6 +13,7 @@ import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Repository
 import java.time.Duration
 import java.time.Instant
+import java.util.UUID
 
 @Repository
 class AuthTokenRepositoryImpl(
@@ -20,6 +21,7 @@ class AuthTokenRepositoryImpl(
     private val om: ObjectMapper,
     private val loginScript: RedisScript<Long>,
     private val logoutScript: RedisScript<Long>,
+    private val logoutAllScript: RedisScript<Long>,
 ) : AuthTokenRepository {
     override fun findRefreshTokenInfo(userInfo: TokenUserInfo): RefreshTokenInfo? {
         val key = makeRefreshTokenKey(userInfo.role, userInfo.userId)
@@ -94,6 +96,26 @@ class AuthTokenRepositoryImpl(
             logoutScript,
             listOf(refreshTokenKey, sessionAgesKey, activeJtiKey),
             logoutDeviceId,
+        )
+    }
+
+    override fun findAllRefreshTokenInfo(userInfo: TokenUserInfo): List<RefreshTokenInfo> {
+        val refreshTokensKey = makeRefreshTokenKey(role = userInfo.role, userId = userInfo.userId)
+        val refreshTokenEntries = rt.opsForHash<String, String>().entries(refreshTokensKey)
+
+        return refreshTokenEntries.values.map { om.readValue(it, RefreshTokenInfo::class.java) }
+    }
+
+    override fun deleteAuthTokenByLogoutAll(userInfo: TokenUserInfo) {
+        // Lua 스크립트 실행을 위한 파라미터 준비 (해당 유저의 모든 AccessToken, RefreshToken 무력화)
+        val refreshTokenKey = makeRefreshTokenKey(role = userInfo.role, userId = userInfo.userId)
+        val sessionAgesKey = makeSessionKey(role = userInfo.role, userId = userInfo.userId)
+
+        // --- 원자적 스크립트 실행 ---
+        rt.execute(
+            logoutAllScript,
+            listOf(refreshTokenKey, sessionAgesKey),
+            UUID.randomUUID().toString(),
         )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/AuthController.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/AuthController.kt
@@ -5,13 +5,16 @@ import msa.hotel.modules.web.response.Response
 import msa.hotel.services.auth.application.auth.AuthService
 import msa.hotel.services.auth.application.auth.dto.AuthTokenDto
 import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
+import msa.hotel.services.auth.infrastructure.web.auth.dto.LogoutAllResponse
 import msa.hotel.services.auth.infrastructure.web.auth.dto.LogoutRequest
 import msa.hotel.services.auth.infrastructure.web.auth.dto.SessionInfoResponse
+import msa.hotel.services.auth.infrastructure.web.auth.dto.SessionInfosResponse
 import msa.hotel.services.auth.infrastructure.web.auth.header.RequestHeaderTokenExtractor
 import msa.hotel.services.auth.infrastructure.web.auth.header.deleteAuthTokenHeaders
 import msa.hotel.services.auth.infrastructure.web.auth.header.setAuthTokenHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -80,6 +83,46 @@ class AuthController(
         return deleteAuthTokenHeaders(
             message = "로그아웃 되었습니다.(${sessionInfo.deviceId})",
             data = data,
+        )
+    }
+
+    @DeleteMapping("/logout-all")
+    fun logoutAll(): ResponseEntity<Response<LogoutAllResponse>> {
+        val accessToken = tokenExtractor.getAccessToken()
+        val sessionInfos = authService.logoutAll(accessToken)
+
+        val data =
+            sessionInfos.map {
+                SessionInfoResponse(
+                    deviceId = it.deviceId,
+                    loginDateTime = it.loginDateTime,
+                    lastActivityDateTime = it.lastActivityDateTime,
+                )
+            }
+
+        return deleteAuthTokenHeaders(
+            message = "모든 기기에서 로그아웃 되었습니다.",
+            data = LogoutAllResponse(data),
+        )
+    }
+
+    @GetMapping("/sessions")
+    fun getSessions(): Response<SessionInfosResponse> {
+        val accessToken = tokenExtractor.getAccessToken()
+        val sessionInfos = authService.getSessions(accessToken)
+
+        val sessions =
+            sessionInfos.map { sessionInfo ->
+                SessionInfoResponse(
+                    deviceId = sessionInfo.deviceId,
+                    loginDateTime = sessionInfo.loginDateTime,
+                    lastActivityDateTime = sessionInfo.lastActivityDateTime,
+                )
+            }
+
+        return Response.read(
+            message = "접속 중인 세션 조회에 성공했습니다.",
+            data = SessionInfosResponse(sessions),
         )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/SessionInfosResponse.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/auth/dto/SessionInfosResponse.kt
@@ -1,0 +1,5 @@
+package msa.hotel.services.auth.infrastructure.web.auth.dto
+
+data class SessionInfosResponse(
+    val sessionInfos: List<SessionInfoResponse>,
+)

--- a/services/auth/src/main/resources/scripts/logout-all.lua
+++ b/services/auth/src/main/resources/scripts/logout-all.lua
@@ -1,0 +1,34 @@
+-- KEYS[1]: refresh_tokens HASH key
+-- KEYS[2]: session_ages ZSET key
+
+-- ARGV[1]: TEMP UUID
+
+-- 1. Hash에 저장된 모든 세션 정보를 가져옴 (Field: deviceId, Value: sessionInfoJson)
+local all_sessions = redis.call('HGETALL', KEYS[1])
+
+-- 2. 모든 Value(JSON)를 순회하며 jti를 추출하고, 해당 active_jti key를 삭제
+--    i=2부터 2씩 증가하며 Value만 순회
+for i = 2, #all_sessions, 2 do
+    local session_info_json = all_sessions[i]
+
+    -- 3. RedisJSON 명령어를 사용해 JSON에서 accessTokenJti 값을 추출합니다.
+    --    JSON.GET은 Key에 대해서만 동작하므로, 임시 Key에 값을 잠깐 저장했다가 사용합니다.
+    redis.call('JSON.SET', ARGV[1], '$', session_info_json)
+    local jti_to_delete_array_string = redis.call('JSON.GET', ARGV[1], 'accessTokenJti')
+
+    -- 4. 추출한 jti로 활성 액세스 토큰 키를 삭제합니다.
+    if jti_to_delete_array_string and #jti_to_delete_array_string > 0 then
+        -- JSON.GET은 결과를 JSON 배열 문자열 '["uuid-123"]' 형태로 반환하므로, 따옴표를 제거합니다.
+        local jti_to_delete = string.sub(jti_to_delete_array_string, 2, -2)
+        redis.call('DEL', "active_jti:" .. jti_to_delete)
+    end
+
+    -- 5. 사용한 임시 Key를 삭제합니다.
+    redis.call('DEL', ARGV[1])
+end
+
+-- 6. Hash와 ZSET Key 자체를 삭제하여 모든 리프레시 토큰 무효화
+redis.call('DEL', KEYS[1])
+redis.call('DEL', KEYS[2])
+
+return #all_sessions / 2 -- 삭제한 세션의 개수를 반환

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
@@ -27,6 +27,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.transaction.annotation.Transactional
 import java.lang.Thread.sleep
@@ -252,6 +253,67 @@ class AuthIntegrationTest(
 
                     val checkActiveJti = repo.existActiveJti(accessTokenInfo.jti)
                     checkActiveJti shouldBe true
+                }
+            }
+
+            When("여러 접속에 로그인 후 모든 기기 로그아웃 API 요청") {
+                val accessTokens = mutableListOf<String>()
+                for (i in 1..3) {
+                    val loginRequest = createLoginRequest(registerCommand, "device-$i")
+                    accessTokens.add(performLoginAndGetTokens(loginRequest).first)
+                }
+                mockMvc
+                    .delete("/auth/logout-all") {
+                        header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessTokens.last()))
+                    }.andExpect {
+                        status { isOk() }
+                    }.andReturn()
+
+                Then("발급됐던 인증 토큰 모두 즉시 무효화") {
+                    // AccessToken 무효화 -> 활성 JTI 내역 모두 삭제
+                    accessTokens.forEach {
+                        val accessTokenInfo = jwtDecoder.extractAuthInfo(it)
+                        val checkActiveJti = repo.existActiveJti(accessTokenInfo.jti)
+                        checkActiveJti shouldBe false
+                    }
+
+                    // 리프레시 토큰 무효화 -> 리프레시 토큰 내역 모두 삭제
+                    val userInfo = jwtDecoder.extractAuthInfo(accessTokens.first()).tokenUserInfo
+                    val refreshTokenInfos = repo.findAllRefreshTokenInfo(userInfo)
+                    refreshTokenInfos.size shouldBe 0
+                }
+            }
+
+            When("여러 디바이스로 로그인 한 후 접속 중인 모든 세션 확인 API 요청") {
+                val accessTokens = mutableListOf<String>()
+                val deviceIds = mutableListOf<String>()
+                for (i in 1..3) {
+                    val deviceId = "device-$i"
+                    deviceIds.add(deviceId)
+                    val loginRequest = createLoginRequest(registerCommand, deviceId)
+                    accessTokens.add(performLoginAndGetTokens(loginRequest).first)
+                }
+
+                val result =
+                    mockMvc
+                        .get("/auth/sessions") {
+                            header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessTokens.last()))
+                        }.andExpect {
+                            status { isOk() }
+                        }.andReturn()
+
+                Then("접속 중인 디바이스 정보 응답") {
+                    val responseBody = om.readTree(result.response.contentAsString)
+                    val message = responseBody.get("message").asText()
+                    message shouldBe "접속 중인 세션 조회에 성공했습니다."
+
+                    // 응답에 접속 디바이스 기기 목록 확인
+                    val sessions = responseBody.get("data").get("sessionInfos").toList()
+                    sessions.size shouldBe 3
+                    sessions.forEach {
+                        val deviceId = it.get("deviceId").asText()
+                        deviceIds.contains(deviceId) shouldBe true
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 📝 개요 (Description)

### 모든 기기 로그아웃 및 활성 세션 조회 API 구현

개별 기기 로그아웃 기능에 이어, 사용자 보안 강화를 위해 **자신을 포함한 모든 기기에서 강제 로그아웃**하는 기능과 현재 **활성화된 모든 세션 목록을 조회**하는 API를 구현했습니다.

## ✨ 주요 변경 사항 (Key Changes)

-   **API 엔드포인트 추가**
    -   **`DELETE /auth/logout-all`**: 현재 요청을 보낸 기기를 포함한, 해당 계정으로 로그인된 모든 기기의 세션을 즉시 무효화합니다.
    -   **`GET /auth/sessions`**: 현재 로그인된 모든 기기의 세션 정보(기기 ID, 로그인 시각, 마지막 활동 시각) 목록을 조회합니다.

-   **모든 세션 일괄 무효화 처리**
    -   사용자의 모든 세션을 한 번에 안전하게 삭제하기 위해 새로운 **Redis Lua 스크립트(`logout-all.lua`)를 작성**했습니다.
    -   이 스크립트는 해당 사용자의 모든 **RefreshToken 정보**와 활성화된 **AccessToken JTI 목록**을 **원자적(Atomic)으로 순회하며 삭제**하여, 데이터 정합성을 보장하고 레이스 컨디션을 방지합니다.

-   **활성 세션 정보 조회**
    -   Redis에 저장된 사용자의 모든 세션 정보를 조회하여 각 기기별 로그인 정보와 마지막 활동 시간을 반환하는 기능을 구현했습니다.
    -   이를 통해 사용자는 자신의 계정이 어떤 기기들에서 활성화되어 있는지 직접 확인하고 관리할 수 있습니다.

-   **보안 검증 로직 추가**
    -   모든 세션을 로그아웃하거나 조회하기 전에, 현재 API를 요청하는 사용자의 AccessToken이 유효한지 먼저 검증하는 로직을 추가하여 인가되지 않은 요청을 차단합니다.

-   **통합 테스트 추가**
    -   여러 기기에서 로그인 후, 모든 기기 로그아웃 API를 호출했을 때 모든 세션이 정상적으로 무효화되는지 검증하는 테스트 케이스를 추가했습니다.
    -   활성 세션 목록 조회 API가 정확한 데이터를 반환하는지 확인하는 통합 테스트도 함께 추가했습니다.