### PR TITLE
[ auth ] 비밀번호 변경 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ subprojects {
 
         sourceSets.main
             .get()
-            .java
+            .kotlin
             .srcDirs("src/main/generated")
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/identity/IdentityLoginService.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/identity/IdentityLoginService.kt
@@ -32,8 +32,9 @@ class IdentityLoginService(
         if (identity.status == Status.LOCKED) {
             checkLockedLogin(identity)
         }
-        if (identity.passwordHash != pwEncoder.encode(password)) {
+        if (!pwEncoder.matches(command.password, identity.passwordHash)) {
             checkFailLoginCount(identity)
+            throw ErrorCode.UNAUTHORIZED.exception("비밀번호가 올바르지 않습니다.")
         }
 
         return identity

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/identity/IdentityService.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/identity/IdentityService.kt
@@ -5,6 +5,7 @@ import jakarta.mail.internet.MimeMessage
 import msa.hotel.modules.idgenerator.IdGenerator
 import msa.hotel.modules.web.exception.ErrorCode
 import msa.hotel.services.auth.application.identity.command.EmailConfirmCommand
+import msa.hotel.services.auth.application.identity.command.PasswordChangeCommand
 import msa.hotel.services.auth.application.identity.command.RegisterIdentityCommand
 import msa.hotel.services.auth.application.identity.command.SendVerifyEmailCommand
 import msa.hotel.services.auth.application.identity.dto.IdentityDto
@@ -123,6 +124,27 @@ class IdentityService(
         identity.verifyMail()
         repo.save(identity)
         emailVerifyTokenRepo.deleteCodeByUserId(identity.id.value)
+
+        return IdentityDto.from(identity)
+    }
+
+    fun changePassword(command: PasswordChangeCommand): IdentityDto {
+        val userInfo = command.authInfo.tokenUserInfo
+        val identity =
+            repo.findById(IdentityId(userInfo.userId))
+                ?: throw ErrorCode.CONFLICT.exception("인증 정보와 일치하는 등록 정보가 존재하지 않습니다")
+
+        if (!pwEncoder.matches(command.currentPassword, identity.passwordHash)) {
+            throw ErrorCode.VALIDATION_ERROR.exception("현재 비밀번호가 올바르지 않습니다")
+        }
+
+        val pwValidResult = PasswordPolicy.validate(command.changePassword)
+        if (!pwValidResult.isValid) {
+            throw ErrorCode.VALIDATION_ERROR.exception("변경하려는 비밀번호가 비밀번호 정책에 위반됩니다 : ${pwValidResult.errorCause}")
+        }
+
+        identity.updatePassword(pwEncoder.encode(command.changePassword))
+        repo.save(identity)
 
         return IdentityDto.from(identity)
     }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/application/identity/command/PasswordChangeCommand.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/application/identity/command/PasswordChangeCommand.kt
@@ -1,0 +1,9 @@
+package msa.hotel.services.auth.application.identity.command
+
+import msa.hotel.modules.jwt.token.dto.TokenAuthInfo
+
+data class PasswordChangeCommand(
+    val authInfo: TokenAuthInfo,
+    val currentPassword: String,
+    val changePassword: String,
+)

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/config/AnnotationConfig.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/config/AnnotationConfig.kt
@@ -1,0 +1,15 @@
+package msa.hotel.services.auth.config
+
+import msa.hotel.services.auth.infrastructure.web.annotations.authinfo.AuthInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class AnnotationConfig(
+    private val authInfoArgumentResolver: AuthInfoArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(authInfoArgumentResolver)
+    }
+}

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/config/SecurityConfig.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/config/SecurityConfig.kt
@@ -26,6 +26,7 @@ class SecurityConfig {
                         "/identity",
                         "/identity/verify/request",
                         "/identity/verify/confirm",
+                        "/identity/password/change",
                     ).permitAll()
                     .requestMatchers(
                         HttpMethod.GET,

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/identity/model/Identity.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/domain/identity/model/Identity.kt
@@ -94,4 +94,9 @@ class Identity(
         failedLoginCount = 0u
         lastLoginAt = loginAt
     }
+
+    fun updatePassword(passwordHash: String) {
+        this.passwordHash = passwordHash
+        this.passwordUpdatedAt = Instant.now()
+    }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/authinfo/AuthInfo.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/authinfo/AuthInfo.kt
@@ -1,0 +1,5 @@
+package msa.hotel.services.auth.infrastructure.web.annotations.authinfo
+
+@Target(AnnotationTarget.TYPE_PARAMETER, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthInfo

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/authinfo/AuthInfoArgumentResolver.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/authinfo/AuthInfoArgumentResolver.kt
@@ -1,0 +1,28 @@
+package msa.hotel.services.auth.infrastructure.web.annotations.authinfo
+
+import msa.hotel.modules.jwt.token.dto.TokenAuthInfo
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class AuthInfoArgumentResolver(
+    private val checkActiveJtiService: CheckActiveJtiService,
+) : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        val hasParameterAnnotation = parameter.hasParameterAnnotation(AuthInfo::class.java)
+        val isTokenAuthInfo = parameter.parameterType == TokenAuthInfo::class.java
+
+        return hasParameterAnnotation && isTokenAuthInfo
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): TokenAuthInfo = checkActiveJtiService.checkActiveJti()
+}

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/authinfo/CheckActiveJtiService.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/authinfo/CheckActiveJtiService.kt
@@ -1,0 +1,26 @@
+package msa.hotel.services.auth.infrastructure.web.annotations.authinfo
+
+import msa.hotel.modules.jwt.token.JwtDecoder
+import msa.hotel.modules.jwt.token.dto.TokenAuthInfo
+import msa.hotel.modules.web.exception.ErrorCode
+import msa.hotel.services.auth.domain.auth.port.AuthTokenRepository
+import msa.hotel.services.auth.infrastructure.web.auth.header.RequestHeaderTokenExtractor
+import org.springframework.stereotype.Service
+
+@Service
+class CheckActiveJtiService(
+    private val tokenExtractor: RequestHeaderTokenExtractor,
+    private val jwtDecoder: JwtDecoder,
+    private val tokenRepo: AuthTokenRepository,
+) {
+    fun checkActiveJti(): TokenAuthInfo {
+        val accessToken = tokenExtractor.getAccessToken()
+        val authInfo = jwtDecoder.extractAuthInfo(accessToken)
+
+        if (!tokenRepo.existActiveJti(authInfo.jti)) {
+            throw ErrorCode.UNAUTHORIZED.exception("로그아웃 처리된 인증 정보입니다")
+        }
+
+        return authInfo
+    }
+}

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/validation/StrongPassword.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/validation/StrongPassword.kt
@@ -1,4 +1,4 @@
-package msa.hotel.services.auth.infrastructure.web.validation
+package msa.hotel.services.auth.infrastructure.web.annotations.validation
 
 import jakarta.validation.Constraint
 import jakarta.validation.Payload

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/validation/StrongPasswordValidator.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/annotations/validation/StrongPasswordValidator.kt
@@ -1,4 +1,4 @@
-package msa.hotel.services.auth.infrastructure.web.validation
+package msa.hotel.services.auth.infrastructure.web.annotations.validation
 
 import jakarta.validation.ConstraintValidator
 import jakarta.validation.ConstraintValidatorContext
@@ -17,7 +17,9 @@ class StrongPasswordValidator : ConstraintValidator<StrongPassword, String> {
         val result = PasswordPolicy.validate(value)
         if (!result.isValid) {
             context.disableDefaultConstraintViolation()
-            context.buildConstraintViolationWithTemplate(result.errorCause ?: "비밀번호가 유효하지 않습니다").addConstraintViolation()
+            context
+                .buildConstraintViolationWithTemplate(result.errorCause ?: "비밀번호가 유효하지 않습니다")
+                .addConstraintViolation()
         }
 
         return result.isValid

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/IdentityController.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/IdentityController.kt
@@ -1,12 +1,16 @@
 package msa.hotel.services.auth.infrastructure.web.identity
 
 import jakarta.validation.Valid
+import msa.hotel.modules.jwt.token.dto.TokenAuthInfo
 import msa.hotel.modules.web.response.Response
 import msa.hotel.services.auth.application.identity.IdentityService
 import msa.hotel.services.auth.application.identity.dto.IdentityDto
 import msa.hotel.services.auth.domain.identity.policy.EmailVerifyPolicy
+import msa.hotel.services.auth.infrastructure.web.annotations.authinfo.AuthInfo
 import msa.hotel.services.auth.infrastructure.web.identity.dto.EmailConfirmRequest
 import msa.hotel.services.auth.infrastructure.web.identity.dto.EmailConfirmResponse
+import msa.hotel.services.auth.infrastructure.web.identity.dto.PasswordChangeRequest
+import msa.hotel.services.auth.infrastructure.web.identity.dto.PasswordChangeResponse
 import msa.hotel.services.auth.infrastructure.web.identity.dto.RegisterIdentityRequest
 import msa.hotel.services.auth.infrastructure.web.identity.dto.RegisterIdentityResponse
 import msa.hotel.services.auth.infrastructure.web.identity.dto.SendVerifyEmailRequest
@@ -72,5 +76,24 @@ class IdentityController(
 
         // 별도 View Client 부재로 간단한 알림창으로 응답 구현
         return EmailVerifyPolicy.confirmResponse(data.email)
+    }
+
+    @PostMapping("/password/change")
+    fun changePassword(
+        @Valid
+        @RequestBody
+        request: PasswordChangeRequest,
+        @AuthInfo
+        authInfo: TokenAuthInfo,
+    ): Response<PasswordChangeResponse> {
+        val command = request.toPasswordChangeCommand(authInfo)
+        val identity: IdentityDto = identityService.changePassword(command)
+
+        val data = PasswordChangeResponse.from(identity)
+
+        return Response.create(
+            message = "비밀번호 변경에 성공했습니다.",
+            data = data,
+        )
     }
 }

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/PasswordChangeRequest.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/PasswordChangeRequest.kt
@@ -1,0 +1,21 @@
+package msa.hotel.services.auth.infrastructure.web.identity.dto
+
+import msa.hotel.modules.jwt.token.dto.TokenAuthInfo
+import msa.hotel.services.auth.application.identity.command.PasswordChangeCommand
+import msa.hotel.services.auth.infrastructure.web.annotations.validation.StrongPassword
+
+@Suppress("ktlint:standard:no-blank-line-in-list")
+data class PasswordChangeRequest(
+    @field:StrongPassword
+    val currentPassword: String?,
+
+    @field:StrongPassword
+    val changePassword: String?,
+) {
+    fun toPasswordChangeCommand(authInfo: TokenAuthInfo): PasswordChangeCommand =
+        PasswordChangeCommand(
+            authInfo = authInfo,
+            currentPassword = currentPassword!!,
+            changePassword = changePassword!!,
+        )
+}

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/PasswordChangeResponse.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/PasswordChangeResponse.kt
@@ -1,0 +1,20 @@
+package msa.hotel.services.auth.infrastructure.web.identity.dto
+
+import msa.hotel.services.auth.application.identity.dto.IdentityDto
+
+data class PasswordChangeResponse(
+    val id: ULong,
+    val email: String,
+    val role: String,
+    val createdAt: String,
+) {
+    companion object {
+        fun from(identity: IdentityDto): PasswordChangeResponse =
+            PasswordChangeResponse(
+                id = identity.id.value,
+                email = identity.email,
+                role = identity.role.name,
+                createdAt = identity.createdAt.toString(),
+            )
+    }
+}

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/RegisterIdentityRequest.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/RegisterIdentityRequest.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import msa.hotel.services.auth.application.identity.command.RegisterIdentityCommand
 import msa.hotel.services.auth.domain.identity.model.Role
-import msa.hotel.services.auth.infrastructure.web.validation.StrongPassword
+import msa.hotel.services.auth.infrastructure.web.annotations.validation.StrongPassword
 
 @Suppress("ktlint:standard:no-blank-line-in-list")
 data class RegisterIdentityRequest(

--- a/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/SendVerifyEmailRequest.kt
+++ b/services/auth/src/main/kotlin/msa/hotel/services/auth/infrastructure/web/identity/dto/SendVerifyEmailRequest.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import msa.hotel.services.auth.application.identity.command.SendVerifyEmailCommand
 
-@Suppress("ktlint:standard:no-blank-line-in-list")
 data class SendVerifyEmailRequest(
     @field:NotBlank(message = "이메일 등록은 필수 입니다.")
     @field:Email(message = "이메일 형식이 유효하지 않습니다.")

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/AuthIntegrationTest.kt
@@ -6,7 +6,6 @@ import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import jakarta.servlet.http.Cookie
 import msa.hotel.modules.jwt.token.JwtDecoder
 import msa.hotel.services.auth.application.identity.IdentityService
 import msa.hotel.services.auth.application.identity.command.RegisterIdentityCommand
@@ -15,7 +14,6 @@ import msa.hotel.services.auth.domain.auth.port.AuthTokenRepository
 import msa.hotel.services.auth.domain.identity.model.Role
 import msa.hotel.services.auth.domain.identity.port.IdentityRepository
 import msa.hotel.services.auth.infrastructure.persistence.redis.key.AuthTokenKey.makeRefreshTokenKey
-import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
 import msa.hotel.services.auth.infrastructure.web.auth.dto.LogoutRequest
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_PREFIX
@@ -47,29 +45,6 @@ class AuthIntegrationTest(
     private val jwtDecoder: JwtDecoder,
     private val redisTemplate: RedisTemplate<String, String>,
 ) : BehaviorSpec({
-        fun performLoginAndGetTokens(request: LoginRequest): Pair<String, Cookie> {
-            val result =
-                mockMvc
-                    .post("/auth/login") {
-                        contentType = MediaType.APPLICATION_JSON
-                        content = om.writeValueAsString(request)
-                    }.andReturn()
-
-            val accessToken = result.response.getHeader(T_ACCESS_HEADER_NAME)!!.substring(7)
-            val refreshTokenCookie = result.response.getCookie(T_REFRESH_COOKIE_NAME)!!
-            return Pair(accessToken, refreshTokenCookie)
-        }
-
-        fun createLoginRequest(
-            command: RegisterIdentityCommand,
-            deviceId: String,
-        ) = LoginRequest(
-            email = command.email,
-            password = command.password,
-            role = command.role,
-            deviceId = deviceId,
-        )
-
         Given("이메일 인증까지 완료한 Identity 제공 및 기본 로그인 디바이스 정보") {
             val registerCommand =
                 RegisterIdentityCommand(
@@ -125,12 +100,12 @@ class AuthIntegrationTest(
                 for (i in 1..maxDeviceCount) {
                     sleep(100)
                     val loginRequest = createLoginRequest(registerCommand, "device-$i")
-                    performLoginAndGetTokens(loginRequest)
+                    performLoginAndGetTokens(loginRequest, mockMvc, om)
                 }
 
                 val newDeviceId = "device-${maxDeviceCount + 1}"
                 val exceededLoginRequest = createLoginRequest(registerCommand, newDeviceId)
-                performLoginAndGetTokens(exceededLoginRequest)
+                performLoginAndGetTokens(exceededLoginRequest, mockMvc, om)
 
                 Then("제일 오래전에 접속한 기기 세션 자동 로그아웃") {
                     val refreshTokensKey =
@@ -152,7 +127,7 @@ class AuthIntegrationTest(
 
             When("로그인 이후 인증 토큰 재발급 API 요청") {
                 val request = createLoginRequest(registerCommand, loginDeviceId)
-                val (pastAccessToken, pastRefreshTokenCookie) = performLoginAndGetTokens(request)
+                val (pastAccessToken, pastRefreshTokenCookie) = performLoginAndGetTokens(request, mockMvc, om)
                 val pastRefreshToken = pastRefreshTokenCookie.value
 
                 val result =
@@ -199,7 +174,7 @@ class AuthIntegrationTest(
 
             When("로그인 이후 로그아웃 API 요청") {
                 val request = createLoginRequest(registerCommand, loginDeviceId)
-                val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(request)
+                val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(request, mockMvc, om)
 
                 val result =
                     mockMvc
@@ -228,11 +203,11 @@ class AuthIntegrationTest(
 
             When("로그인한 인증 정보로 다른 Device로 접속 세션 로그아웃 API 요청") {
                 val loginRequest = createLoginRequest(registerCommand, loginDeviceId)
-                val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest)
+                val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest, mockMvc, om)
 
                 val anotherDeviceId = "another-device"
                 val anotherLoginRequest = createLoginRequest(registerCommand, anotherDeviceId)
-                val anotherAccessToken = performLoginAndGetTokens(anotherLoginRequest).first
+                val anotherAccessToken = performLoginAndGetTokens(anotherLoginRequest, mockMvc, om).first
 
                 val logoutRequest = LogoutRequest(anotherDeviceId)
 
@@ -270,7 +245,7 @@ class AuthIntegrationTest(
                 val accessTokens = mutableListOf<String>()
                 for (i in 1..3) {
                     val loginRequest = createLoginRequest(registerCommand, "device-$i")
-                    accessTokens.add(performLoginAndGetTokens(loginRequest).first)
+                    accessTokens.add(performLoginAndGetTokens(loginRequest, mockMvc, om).first)
                 }
                 mockMvc
                     .delete("/auth/logout-all") {
@@ -301,7 +276,7 @@ class AuthIntegrationTest(
                     val deviceId = "device-$i"
                     deviceIds.add(deviceId)
                     val loginRequest = createLoginRequest(registerCommand, deviceId)
-                    accessTokens.add(performLoginAndGetTokens(loginRequest).first)
+                    accessTokens.add(performLoginAndGetTokens(loginRequest, mockMvc, om).first)
                 }
 
                 val result =

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/PerformLoginAndGetTokens.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/auth/PerformLoginAndGetTokens.kt
@@ -1,0 +1,38 @@
+package msa.hotel.services.auth.auth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.Cookie
+import msa.hotel.services.auth.application.identity.command.RegisterIdentityCommand
+import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
+import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
+import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_REFRESH_COOKIE_NAME
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+
+fun performLoginAndGetTokens(
+    request: LoginRequest,
+    mockMvc: MockMvc,
+    om: ObjectMapper,
+): Pair<String, Cookie> {
+    val result =
+        mockMvc
+            .post("/auth/login") {
+                contentType = MediaType.APPLICATION_JSON
+                content = om.writeValueAsString(request)
+            }.andReturn()
+
+    val accessToken = result.response.getHeader(T_ACCESS_HEADER_NAME)!!.substring(7)
+    val refreshTokenCookie = result.response.getCookie(T_REFRESH_COOKIE_NAME)!!
+    return Pair(accessToken, refreshTokenCookie)
+}
+
+fun createLoginRequest(
+    command: RegisterIdentityCommand,
+    deviceId: String,
+) = LoginRequest(
+    email = command.email,
+    password = command.password,
+    role = command.role,
+    deviceId = deviceId,
+)

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/config/ProjectConfig.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/config/ProjectConfig.kt
@@ -1,0 +1,10 @@
+package msa.hotel.services.auth.config
+
+import io.kotest.core.config.AbstractProjectConfig
+
+object ProjectConfig : AbstractProjectConfig() {
+    @Deprecated("use beforeProject supports suspension", replaceWith = ReplaceWith("beforeProject"))
+    override fun beforeAll() {
+        DotenvLoader.load()
+    }
+}

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/config/ProjectConfig.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/config/ProjectConfig.kt
@@ -3,7 +3,6 @@ package msa.hotel.services.auth.config
 import io.kotest.core.config.AbstractProjectConfig
 
 object ProjectConfig : AbstractProjectConfig() {
-    @Deprecated("use beforeProject supports suspension", replaceWith = ReplaceWith("beforeProject"))
     override fun beforeAll() {
         DotenvLoader.load()
     }

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/identity/IdentityIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/identity/IdentityIntegrationTest.kt
@@ -6,19 +6,18 @@ import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import jakarta.servlet.http.Cookie
 import msa.hotel.modules.web.response.Response
 import msa.hotel.modules.web.support.toResponse
 import msa.hotel.services.auth.application.identity.IdentityService
 import msa.hotel.services.auth.application.identity.command.RegisterIdentityCommand
+import msa.hotel.services.auth.auth.createLoginRequest
+import msa.hotel.services.auth.auth.performLoginAndGetTokens
 import msa.hotel.services.auth.domain.identity.model.IdentityId
 import msa.hotel.services.auth.domain.identity.model.Role
 import msa.hotel.services.auth.domain.identity.model.Status
 import msa.hotel.services.auth.domain.identity.port.EmailVerifyCodeRepository
 import msa.hotel.services.auth.domain.identity.port.IdentityRepository
-import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
 import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
-import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_REFRESH_COOKIE_NAME
 import msa.hotel.services.auth.infrastructure.web.auth.header.makeAccessTokenHeaderValue
 import msa.hotel.services.auth.infrastructure.web.identity.dto.PasswordChangeRequest
 import msa.hotel.services.auth.infrastructure.web.identity.dto.PasswordChangeResponse
@@ -147,29 +146,6 @@ class IdentityIntegrationTest(
             }
         }
 
-        fun performLoginAndGetTokens(request: LoginRequest): Pair<String, Cookie> {
-            val result =
-                mockMvc
-                    .post("/auth/login") {
-                        contentType = MediaType.APPLICATION_JSON
-                        content = om.writeValueAsString(request)
-                    }.andReturn()
-
-            val accessToken = result.response.getHeader(T_ACCESS_HEADER_NAME)!!.substring(7)
-            val refreshTokenCookie = result.response.getCookie(T_REFRESH_COOKIE_NAME)!!
-            return Pair(accessToken, refreshTokenCookie)
-        }
-
-        fun createLoginRequest(
-            command: RegisterIdentityCommand,
-            deviceId: String,
-        ) = LoginRequest(
-            email = command.email,
-            password = command.password,
-            role = command.role,
-            deviceId = deviceId,
-        )
-
         Given("이메일 검증까지 완료된 후 로그인 완료") {
             val registerCommand =
                 RegisterIdentityCommand(
@@ -183,7 +159,7 @@ class IdentityIntegrationTest(
             repo.save(identity)
 
             val loginRequest = createLoginRequest(registerCommand, "test-device-1")
-            val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest)
+            val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest, mockMvc, om)
 
             When("로그인된 인증 정보로 비밀번호 변경 API 요청") {
                 val request =

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/identity/IdentityIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/identity/IdentityIntegrationTest.kt
@@ -6,13 +6,22 @@ import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import jakarta.servlet.http.Cookie
 import msa.hotel.modules.web.response.Response
 import msa.hotel.modules.web.support.toResponse
+import msa.hotel.services.auth.application.identity.IdentityService
+import msa.hotel.services.auth.application.identity.command.RegisterIdentityCommand
 import msa.hotel.services.auth.domain.identity.model.IdentityId
 import msa.hotel.services.auth.domain.identity.model.Role
 import msa.hotel.services.auth.domain.identity.model.Status
 import msa.hotel.services.auth.domain.identity.port.EmailVerifyCodeRepository
 import msa.hotel.services.auth.domain.identity.port.IdentityRepository
+import msa.hotel.services.auth.infrastructure.web.auth.dto.LoginRequest
+import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_ACCESS_HEADER_NAME
+import msa.hotel.services.auth.infrastructure.web.auth.header.HeaderConstants.T_REFRESH_COOKIE_NAME
+import msa.hotel.services.auth.infrastructure.web.auth.header.makeAccessTokenHeaderValue
+import msa.hotel.services.auth.infrastructure.web.identity.dto.PasswordChangeRequest
+import msa.hotel.services.auth.infrastructure.web.identity.dto.PasswordChangeResponse
 import msa.hotel.services.auth.infrastructure.web.identity.dto.RegisterIdentityRequest
 import msa.hotel.services.auth.infrastructure.web.identity.dto.RegisterIdentityResponse
 import msa.hotel.services.auth.infrastructure.web.identity.dto.SendVerifyEmailRequest
@@ -38,6 +47,7 @@ class IdentityIntegrationTest(
     private val repo: IdentityRepository,
     private val passwordEncoder: PasswordEncoder,
     private val emailVerifyCodeRepo: EmailVerifyCodeRepository,
+    private val identityService: IdentityService,
 ) : BehaviorSpec({
         Given("정상적인 신규 Identity 등록 정보") {
             val request =
@@ -133,6 +143,73 @@ class IdentityIntegrationTest(
                     // 이메일 인증 코드 redis 삭제됨
                     code = emailVerifyCodeRepo.findCodeByUserId(userId)
                     code shouldBe null
+                }
+            }
+        }
+
+        fun performLoginAndGetTokens(request: LoginRequest): Pair<String, Cookie> {
+            val result =
+                mockMvc
+                    .post("/auth/login") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = om.writeValueAsString(request)
+                    }.andReturn()
+
+            val accessToken = result.response.getHeader(T_ACCESS_HEADER_NAME)!!.substring(7)
+            val refreshTokenCookie = result.response.getCookie(T_REFRESH_COOKIE_NAME)!!
+            return Pair(accessToken, refreshTokenCookie)
+        }
+
+        fun createLoginRequest(
+            command: RegisterIdentityCommand,
+            deviceId: String,
+        ) = LoginRequest(
+            email = command.email,
+            password = command.password,
+            role = command.role,
+            deviceId = deviceId,
+        )
+
+        Given("이메일 검증까지 완료된 후 로그인 완료") {
+            val registerCommand =
+                RegisterIdentityCommand(
+                    email = "${UUID.randomUUID()}@email.com",
+                    password = "test1234!",
+                    role = Role.MEMBER,
+                )
+            val identityDto = identityService.register(registerCommand)
+            val identity = repo.findById(IdentityId(identityDto.id.value))!!
+            identity.verifyMail()
+            repo.save(identity)
+
+            val loginRequest = createLoginRequest(registerCommand, "test-device-1")
+            val (accessToken, refreshTokenCookie) = performLoginAndGetTokens(loginRequest)
+
+            When("로그인된 인증 정보로 비밀번호 변경 API 요청") {
+                val request =
+                    PasswordChangeRequest(
+                        currentPassword = registerCommand.password,
+                        changePassword = "1234test!",
+                    )
+                val apiResult =
+                    mockMvc
+                        .post("/identity/password/change") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = om.writeValueAsString(request)
+                            cookie(refreshTokenCookie)
+                            header(T_ACCESS_HEADER_NAME, makeAccessTokenHeaderValue(accessToken))
+                        }.andExpect {
+                            status { isOk() }
+                        }.andReturn()
+                Then("비밀번호 변경 확인") {
+                    val response: Response<PasswordChangeResponse> = apiResult.toResponse(om)
+                    response.message shouldBe "비밀번호 변경에 성공했습니다."
+                    response.data!!.id shouldBe identity.id.value
+                    response.data!!.email shouldBe identity.email
+                    response.data!!.role shouldBe identity.role.name
+
+                    val savedIdentity = repo.findById(IdentityId(identity.id.value))!!
+                    passwordEncoder.matches(request.changePassword!!, savedIdentity.passwordHash) shouldBe true
                 }
             }
         }

--- a/services/auth/src/test/kotlin/msa/hotel/services/auth/identity/IdentityIntegrationTest.kt
+++ b/services/auth/src/test/kotlin/msa/hotel/services/auth/identity/IdentityIntegrationTest.kt
@@ -180,9 +180,10 @@ class IdentityIntegrationTest(
                 Then("비밀번호 변경 확인") {
                     val response: Response<PasswordChangeResponse> = apiResult.toResponse(om)
                     response.message shouldBe "비밀번호 변경에 성공했습니다."
-                    response.data!!.id shouldBe identity.id.value
-                    response.data!!.email shouldBe identity.email
-                    response.data!!.role shouldBe identity.role.name
+                    val data = response.data!!
+                    data.id shouldBe identity.id.value
+                    data.email shouldBe identity.email
+                    data.role shouldBe identity.role.name
 
                     val savedIdentity = repo.findById(IdentityId(identity.id.value))!!
                     passwordEncoder.matches(request.changePassword!!, savedIdentity.passwordHash) shouldBe true

--- a/services/auth/src/test/resources/application-test.yml
+++ b/services/auth/src/test/resources/application-test.yml
@@ -15,6 +15,6 @@ spring:
     enabled: true
     baseline-on-migrate: true # 기존에 테이블이 있는 DB에 처음 적용할 때, 현재 상태를 기준으로 삼는 설정
     schemas: test-auth-db
-  mail:
-    username: ${MAIL_TEST_USERNAME}
-    password: ${MAIL_TEST_PASSWORD}
+#  mail:
+#    username: ${MAIL_TEST_USERNAME}
+#    password: ${MAIL_TEST_PASSWORD}


### PR DESCRIPTION
## 📝 개요 (Description)

###  로그인된 사용자를 위한 비밀번호 변경 API 구현

사용자가 자신의 계정 보안을 직접 관리할 수 있도록, 로그인된 상태에서 **현재 비밀번호를 확인하고 새 비밀번호로 변경**하는 API(`POST /identity/password/change`)를 구현했습니다.

## ✨ 주요 변경 사항 (Key Changes)

-   **비밀번호 변경 API 엔드포인트 추가 (`POST /identity/password/change`)**
    -   사용자는 현재 비밀번호와 변경할 새 비밀번호를 요청 본문에 담아 전송합니다.
    -   변경 성공 시, 업데이트된 사용자 정보를 응답합니다.

-   **`@AuthInfo` 커스텀 어노테이션 및 Argument Resolver 도입**
    -   API 호출 시 `Authorization` 헤더의 **AccessToken을 자동으로 검증하고 사용자 정보(`TokenAuthInfo`)를 컨트롤러 메서드에 주입**해주는 `@AuthInfo` 어노테이션을 구현했습니다.
    -   이를 통해 인증이 필요한 API에서 반복적인 토큰 검증 코드를 제거하고, 컨트롤러가 비즈니스 로직에 더 집중할 수 있도록 구조를 개선했습니다.

-   **비밀번호 변경 로직 구현**
    -   `IdentityService`에 비밀번호 변경 로직을 추가했습니다.
    -   요청으로 들어온 **현재 비밀번호가 DB에 저장된 해시값과 일치하는지 먼저 검증**합니다.
    -   변경할 새 비밀번호가 사전에 정의된 **비밀번호 정책(`PasswordPolicy`)을 만족하는지 검증**합니다.
    -   모든 검증을 통과하면, `Identity` 도메인 엔티티의 `updatePassword` 메서드를 호출하여 비밀번호 해시와 변경 시각을 안전하게 업데이트합니다.

-   **통합 테스트 추가**
    -   로그인 후 발급받은 토큰으로 비밀번호 변경 API를 호출하고, 변경된 비밀번호로 재 로그인이 가능한지 확인하는 **end-to-end 시나리오의 통합 테스트**를 추가하여 기능의 안정성을 확보했습니다.
